### PR TITLE
perf: lock-free combinators, fix pool reuse P0 and cache race

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 go-version: [1.23.x, 1.24.x, 1.25.x]
-                os: [ubuntu-latest, macos-latest, windows-latest]
+                os: [ubuntu-latest, macos-15, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/setup-go@v4
@@ -17,4 +17,4 @@ jobs:
                   go-version: "${{ matrix.go-version }}"
             - uses: actions/checkout@v3
             - name: Test
-              run: go test -v ./...
+              run: go test -race -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 .vscode
 .DS_Store
 .serena
+.agent-work-b652f803

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A lightweight Promise library for Go, inspired by the JavaScript Promise API. Vo
 - **Zero dependencies** — standard library only
 - **Thread-safe** — `sync.RWMutex` protects all state transitions
 - **Immutable state** — once settled (`Fulfilled` / `Rejected`), state never changes
-- **High performance** — `sync.Pool`-based closure reuse, O(1) allocations for collection combinators
+- **High performance** — lock-free atomic dispatch in collection combinators, constant per-link allocations in chained APIs
 
 **Requires Go 1.23+.**
 
@@ -30,9 +30,9 @@ go get github.com/shengyanli1982/vowlink
 ```go
 import vl "github.com/shengyanli1982/vowlink"
 
-result := vl.NewPromise(func(resolve, reject func(interface{}, error)) {
+result := vl.NewPromise(func(resolve, reject func(any, error)) {
     resolve("hello", nil)
-}).Then(func(v interface{}) (interface{}, error) {
+}).Then(func(v any) (any, error) {
     return v.(string) + " vowlink", nil
 }, nil)
 
@@ -60,8 +60,8 @@ Every Promise starts as `Pending` and transitions to exactly one terminal state.
 All handlers follow a unified signature for maximum flexibility:
 
 ```go
-func onFulfilled(value interface{}) (interface{}, error)
-func onRejected(reason error) (interface{}, error)
+func onFulfilled(value any) (any, error)
+func onRejected(reason error) (any, error)
 ```
 
 - Return `(value, nil)` → downstream **Fulfills** with `value`
@@ -78,6 +78,8 @@ Both `resolve` and `reject` accept `(value, error)`. The dispatch logic determin
 | `resolve(value, err)` | Fulfills; `Then` calls `onRejected` (error takes priority) |
 | `reject(nil, err)`    | Rejects; `Then` calls `onRejected`                         |
 
+Inside combinators, `resolve(value, err)` is treated as a rejection: `All`/`Race` reject with `err`, `AllSettled` stores `err` in its result slice, and `Any` records `err` in the `AggregateError`. As in `Then`, the error takes priority and `value` is discarded.
+
 ## API Reference
 
 ### Instance Methods
@@ -87,28 +89,30 @@ Both `resolve` and `reject` accept `(value, error)`. The dispatch logic determin
 | `Then(onFulfilled, onRejected)` | Register callbacks; returns new Promise. Either handler may be `nil` |
 | `Catch(onRejected)`             | Shorthand for `Then(nil, onRejected)`                                |
 | `Finally(cleanup)`              | Always runs cleanup handler; returning `error` rejects downstream    |
-| `GetValue() interface{}`        | Returns resolved value, or `nil` if not yet fulfilled                |
+| `GetValue() any`        | Returns resolved value, or `nil` if not yet fulfilled                |
 | `GetReason() error`             | Returns rejection reason, or `nil` if not rejected                   |
 
 ### Combinators
 
 | Function                  | Settles When                   | Result                                    |
 | ------------------------- | ------------------------------ | ----------------------------------------- |
-| `All(p1, p2, ...)`        | All fulfill OR first rejects   | `[]interface{}` of values, or first error |
+| `All(p1, p2, ...)`        | All fulfill OR first rejects   | `[]any` of values, or first error |
 | `Race(p1, p2, ...)`       | First settles (any state)      | Value/error of the winner                 |
 | `Any(p1, p2, ...)`        | First fulfills OR all reject   | First value, or `*AggregateError`         |
-| `AllSettled(p1, p2, ...)` | All settle (fulfill or reject) | `[]interface{}` mixing values and errors  |
+| `AllSettled(p1, p2, ...)` | All settle (fulfill or reject) | `[]any` mixing values and errors  |
+
+**Empty input:** `Race()` fulfills immediately with `nil` — a deliberate design choice, unlike JavaScript where an empty race stays pending forever. `Any()` rejects with an empty `*AggregateError`.
 
 ## Usage Examples
 
 ### Chain & Error Handling
 
 ```go
-result := vl.NewPromise(func(resolve, reject func(interface{}, error)) {
+result := vl.NewPromise(func(resolve, reject func(any, error)) {
     reject(nil, fmt.Errorf("network timeout"))
-}).Then(func(v interface{}) (interface{}, error) {
+}).Then(func(v any) (any, error) {
     return v, nil // skipped on rejection
-}, nil).Catch(func(err error) (interface{}, error) {
+}, nil).Catch(func(err error) (any, error) {
     return nil, fmt.Errorf("wrapped: %w", err)
 })
 
@@ -120,11 +124,11 @@ fmt.Println(result.GetReason()) // wrapped: network timeout
 Returning a value with `nil` error in `Catch` **recovers** the chain:
 
 ```go
-result := vl.NewPromise(func(resolve, reject func(interface{}, error)) {
+result := vl.NewPromise(func(resolve, reject func(any, error)) {
     reject(nil, fmt.Errorf("disk full"))
-}).Catch(func(err error) (interface{}, error) {
+}).Catch(func(err error) (any, error) {
     return "fallback data", nil // recover: chain becomes Fulfilled
-}).Then(func(v interface{}) (interface{}, error) {
+}).Then(func(v any) (any, error) {
     return fmt.Sprintf("got: %v", v), nil
 }, nil)
 
@@ -136,12 +140,12 @@ fmt.Println(result.GetValue()) // got: fallback data
 `Finally` runs regardless of state. If the cleanup handler returns an error, downstream rejects:
 
 ```go
-vl.NewPromise(func(resolve, reject func(interface{}, error)) {
+vl.NewPromise(func(resolve, reject func(any, error)) {
     resolve("data", nil)
 }).Finally(func() error {
     fmt.Println("cleanup done") // always prints
     return nil
-}).Then(func(v interface{}) (interface{}, error) {
+}).Then(func(v any) (any, error) {
     fmt.Println(v) // data
     return v, nil
 }, nil)
@@ -152,14 +156,14 @@ vl.NewPromise(func(resolve, reject func(interface{}, error)) {
 Use goroutines inside the executor for async work. VowLink dispatches subscribers when settled:
 
 ```go
-p := vl.NewPromise(func(resolve, reject func(interface{}, error)) {
+p := vl.NewPromise(func(resolve, reject func(any, error)) {
     go func() {
         time.Sleep(100 * time.Millisecond)
         resolve("async result", nil)
     }()
 })
 
-p.Then(func(v interface{}) (interface{}, error) {
+p.Then(func(v any) (any, error) {
     fmt.Println(v) // async result (called when settled)
     return v, nil
 }, nil)
@@ -168,12 +172,12 @@ p.Then(func(v interface{}) (interface{}, error) {
 ### Collection Combinators
 
 ```go
-p1 := vl.NewPromise(func(r, _ func(interface{}, error)) { r("A", nil) })
-p2 := vl.NewPromise(func(r, _ func(interface{}, error)) { r("B", nil) })
-p3 := vl.NewPromise(func(r, _ func(interface{}, error)) { r("C", nil) })
+p1 := vl.NewPromise(func(r, _ func(any, error)) { r("A", nil) })
+p2 := vl.NewPromise(func(r, _ func(any, error)) { r("B", nil) })
+p3 := vl.NewPromise(func(r, _ func(any, error)) { r("C", nil) })
 
 // All: collect results in order
-values := vl.All(p1, p2, p3).GetValue().([]interface{})
+values := vl.All(p1, p2, p3).GetValue().([]any)
 // [A B C]
 
 // Race: first settled wins
@@ -184,7 +188,7 @@ winner := vl.Race(p1, p2, p3).GetValue()
 result := vl.Any(p1, p2, p3)
 
 // AllSettled: wait for all, collect values and errors
-mixed := vl.AllSettled(p1, p2, p3).GetValue().([]interface{})
+mixed := vl.AllSettled(p1, p2, p3).GetValue().([]any)
 ```
 
 ## Concurrency
@@ -196,17 +200,26 @@ VowLink is designed for concurrent use. Multiple goroutines can safely call `res
 - Subscriber callbacks in `Then`/`Catch`/`Finally` execute **synchronously** on the caller's goroutine
 - Do not block inside callbacks — spawn a goroutine if you need async work
 - `GetValue()` and `GetReason()` are safe to call from any goroutine at any time
+- **Early-settle retention** — after `All`/`Any`/`Race` settles early, subscribers on the remaining pending inputs stay attached until each input settles (no unsubscription, matching JavaScript semantics)
+- **Settle cascade depth** — callbacks run synchronously on the settling goroutine, so settling a pending `Then` chain recurses to a depth equal to the chain length; Go's growable stacks support real-world depths (tests cover 10000 links), but consider splitting extremely deep chains or dispatching them asynchronously
 
 ## Benchmarks
 
 ```
-$ go test -bench=. -benchmem -count=1
-BenchmarkPromiseThenChain/chain=1       2 allocs/op    192 B/op
-BenchmarkPromiseThenChain/chain=32     33 allocs/op   3.1 KB/op
-BenchmarkPromiseAll/size=128            7 allocs/op   2.5 KB/op
-BenchmarkPromiseRace/size=128           4 allocs/op   0.4 KB/op
-BenchmarkAggregateError/size=64         0 allocs/op      0 B/op
+$ go test -bench=. -benchmem -count=5
+BenchmarkPromiseThenChain/chain=1          6 allocs/op    256 B/op
+BenchmarkPromiseThenChain/chain=32        99 allocs/op   4.1 KB/op
+BenchmarkPromiseFinally                    8 allocs/op    288 B/op
+BenchmarkPromiseAll/size=128               8 allocs/op   2.5 KB/op
+BenchmarkPromiseAllSettled/size=128        8 allocs/op   2.5 KB/op
+BenchmarkPromiseAny/first-fulfilled        8 allocs/op   0.7 KB/op
+BenchmarkPromiseRace/size=128              6 allocs/op   0.2 KB/op
+BenchmarkAggregateError/cached/size=64     0 allocs/op      0 B/op
+BenchmarkPromiseThenPending                7 allocs/op    320 B/op
+BenchmarkPromiseAllPending/size=128      522 allocs/op  28.7 KB/op
 ```
+
+NewPromise deliberately spends 2 closure allocations per call for correctness, preventing cross-Promise contamination from pooled closures; the collection combinators are lock-free atomic, and AllPending measures the async subscription path.
 
 ## Examples
 

--- a/examples/case0/demo.go
+++ b/examples/case0/demo.go
@@ -8,13 +8,13 @@ import (
 
 func main() {
 	// vowlink 像一个链条，你可以在链条上添加更多的 then() 来在 promise 解析后做更多的事情
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在第一个 Then 方法中，我们将解析的值加上 " vowlink"
 		return value.(string) + " vowlink", nil
-	}, nil).Then(func(value interface{}) (interface{}, error) {
+	}, nil).Then(func(value any) (any, error) {
 		// 在第二个 Then 方法中，我们将解析的值加上 " !!"
 		return value.(string) + " !!", nil
 	}, nil)

--- a/examples/case1/demo.go
+++ b/examples/case1/demo.go
@@ -8,13 +8,13 @@ import (
 
 func main() {
 	// vowlink 像一个链条，你可以在链条上添加更多的 then() 来在 promise 解析后做更多的事情
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, func(err error) (interface{}, error) {
+	}, func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	})
@@ -23,13 +23,13 @@ func main() {
 	fmt.Println("Resolve:", result.GetValue())
 
 	// 这是一个被拒绝的 promise
-	result = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 被拒绝，原因是 "error"
 		reject(nil, fmt.Errorf("error"))
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 如果 promise 被解析，我们将解析的值加上 " vowlink"
 		return value.(string) + " vowlink", nil
-	}, func(err error) (interface{}, error) {
+	}, func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	})

--- a/examples/case10/demo.go
+++ b/examples/case10/demo.go
@@ -10,39 +10,39 @@ import (
 func main() {
 
 	// 创建一个新的 Promise
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 Promise 会立即被拒绝，原因是 "rejected.100"
 		reject(nil, fmt.Errorf("rejected.100"))
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 1")
 
 		// 返回一个新的错误，将会被下一个 Catch 函数接收
 		return nil, err
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当上一个 Catch 函数返回错误时，会执行这个 Catch 函数
 		fmt.Println("> catch 2")
 
 		// 返回一个新的值，将会被下一个 Then 函数接收
 		return "[error handled]", nil
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当上一个 Catch 函数返回错误时，会执行这个 Catch 函数
 		fmt.Println("> catch 3")
 
 		// 返回一个新的错误，将会被下一个 Catch 函数接收
 		return nil, errors.New("rejected.200")
 
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 		fmt.Println("> then 1")
 
 		// 返回一个新的值，将会被下一个 Then 函数接收
 		return fmt.Sprintf("Should be here. recover value: %v", value), nil
 
-	}, func(err error) (interface{}, error) {
+	}, func(err error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 4")
 

--- a/examples/case11/demo.go
+++ b/examples/case11/demo.go
@@ -11,25 +11,25 @@ import (
 func main() {
 
 	// 创建一个新的 Promise
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 Promise 将继续执行，并将错误 "Something went wrong" 作为值传递给下一个 Promise
 		resolve(errors.New("Something went wrong"), nil)
 
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 		fmt.Println("> then 1")
 
 		// 返回错误的字符串表示形式
 		return data.(error).Error(), nil
 
-	}, func(error) (interface{}, error) {
+	}, func(error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 1")
 
 		// 返回一个新的错误 "Handled error"
 		return nil, errors.New("Handled error")
 
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 2")
 

--- a/examples/case12/demo.go
+++ b/examples/case12/demo.go
@@ -10,25 +10,25 @@ import (
 func main() {
 
 	// 创建一个新的 Promise
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 Promise 将继续执行，并将错误 "Something went wrong" 作为值传递给下一个 Promise
 		reject("Something went wrong", nil)
 
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 		fmt.Println("> then 1")
 
 		// 返回解决的值，将会被下一个 Then 函数接收
 		return data, nil
 
-	}, func(error) (interface{}, error) {
+	}, func(error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 1")
 
 		// 返回一个新的错误 "Handled error"
 		return nil, errors.New("Handled error")
 
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 2")
 

--- a/examples/case2/demo.go
+++ b/examples/case2/demo.go
@@ -8,13 +8,13 @@ import (
 
 func main() {
 	// vowlink 像一个链条，你可以在链条上添加更多的 then() 来在 promise 解析后做更多的事情。
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	})
@@ -23,13 +23,13 @@ func main() {
 	fmt.Println("Resolve:", result.GetValue())
 
 	// 这是一个被拒绝的 promise
-	result = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 被拒绝，原因是 "error"
 		reject(nil, fmt.Errorf("error"))
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 如果 promise 被解析，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	})

--- a/examples/case3/demo.go
+++ b/examples/case3/demo.go
@@ -13,13 +13,13 @@ func main() {
 	fmt.Println("========== finally 1 successfully ==========")
 
 	// vowlink 像一个链条，你可以在链条上添加更多的 then() 来在 promise 解析后做更多的事情。
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	}).Finally(func() error {
@@ -37,13 +37,13 @@ func main() {
 	// 输出 "========== finally 1 error ==========" 到控制台
 	fmt.Println("========== finally 1 error ==========")
 
-	result = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	}).Finally(func() error {
@@ -52,12 +52,12 @@ func main() {
 
 		// 返回一个新的错误 "error in finally 1"
 		return errors.New("error in finally 1")
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 
 		// 返回解决的值，将会被下一个 Then 函数接收
 		return data.(string) + " vowlink", nil
-	}, func(reason error) (interface{}, error) {
+	}, func(reason error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 
 		// 返回一个新的错误 "Handled error: " 加上原因的错误信息
@@ -72,13 +72,13 @@ func main() {
 	fmt.Println("========== finally 2 successfully ==========")
 
 	// 这是一个被拒绝的 promise
-	result = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 被拒绝，原因是 "error"
 		reject(nil, fmt.Errorf("error"))
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 如果 promise 被解析，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	}).Finally(func() error {
@@ -97,13 +97,13 @@ func main() {
 	fmt.Println("========== finally 2 error ==========")
 
 	// 这是一个被拒绝的 promise，Finally 方法中返回了一个错误信息
-	result = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 被拒绝，原因是 "error"
 		reject(nil, fmt.Errorf("error"))
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 如果 promise 被解析，我们将解析的值加上 " vowlink !!"
 		return value.(string) + " vowlink !!", nil
-	}, nil).Catch(func(err error) (interface{}, error) {
+	}, nil).Catch(func(err error) (any, error) {
 		// 如果 promise 被拒绝，我们将返回一个新的错误信息 "rejected."
 		return nil, fmt.Errorf("rejected.")
 	}).Finally(func() error {
@@ -115,12 +115,12 @@ func main() {
 		// 返回一个新的错误 "error in finally 2"
 		return errors.New("error in finally 2")
 
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 
 		// 返回解决的值，将会被下一个 Then 函数接收
 		return data.(string) + " vowlink", nil
-	}, func(reason error) (interface{}, error) {
+	}, func(reason error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 
 		// 返回一个新的错误 "Handled error: " 加上原因的错误信息

--- a/examples/case4/demo.go
+++ b/examples/case4/demo.go
@@ -8,15 +8,15 @@ import (
 
 func main() {
 	// vowlink 像一个链条，你可以在链条上添加更多的 then() 来在 promise 解析后做更多的事情。
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 promise 直接解析为 "hello world"
 		resolve("hello world", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，我们创建一个新的 promise，将解析的值加上 " vowlink(NewPromise)"
-		return vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		return vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve(value.(string)+" vowlink(NewPromise)", nil)
 		}), nil
-	}, nil).Then(func(value interface{}) (interface{}, error) {
+	}, nil).Then(func(value any) (any, error) {
 		// 在这个 Then 方法中，我们获取前一个 promise 的值，并加上 " !!"
 		return value.(*vl.Promise).GetValue().(string) + " !!", nil
 	}, nil)

--- a/examples/case5/demo.go
+++ b/examples/case5/demo.go
@@ -8,26 +8,26 @@ import (
 
 func main() {
 	// 创建 3 个 promise
-	p1 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p1 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第一个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 1"
 		return value.(string) + " 1", nil
 	}, nil)
 
-	p2 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p2 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第二个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 2"
 		return value.(string) + " 2", nil
 	}, nil)
 
-	p3 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p3 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第三个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 3"
 		return value.(string) + " 3", nil
 	}, nil)
@@ -36,7 +36,7 @@ func main() {
 	result := vl.All(p1, p2, p3)
 
 	// 从 promise 中获取所有的值并打印
-	for i, str := range result.GetValue().([]interface{}) {
+	for i, str := range result.GetValue().([]any) {
 		fmt.Println(">>", i, str.(string))
 	}
 }

--- a/examples/case6/demo.go
+++ b/examples/case6/demo.go
@@ -8,26 +8,26 @@ import (
 
 func main() {
 	// 创建 3 个 promise
-	p1 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p1 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第一个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 1"
 		return value.(string) + " 1", nil
 	}, nil)
 
-	p2 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p2 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第二个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 2"
 		return value.(string) + " 2", nil
 	}, nil)
 
-	p3 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p3 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第三个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 3"
 		return value.(string) + " 3", nil
 	}, nil)

--- a/examples/case7/demo.go
+++ b/examples/case7/demo.go
@@ -9,26 +9,26 @@ import (
 
 func main() {
 	// 创建 3 个 promise
-	p1 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p1 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第一个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 1"
 		return value.(string) + " 1", nil
 	}, nil)
 
-	p2 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p2 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第二个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 2"
 		return value.(string) + " 2", nil
 	}, nil)
 
-	p3 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p3 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第三个 promise 直接解析为 "Promise"
 		resolve("Promise", nil)
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 在 Then 方法中，将解析的值加上 " 3"
 		return value.(string) + " 3", nil
 	}, nil)
@@ -40,17 +40,17 @@ func main() {
 	fmt.Println(">>", result.GetValue().(string))
 
 	// 创建 3 个 promise
-	p1 = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p1 = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第一个 promise 被拒绝，原因是 "Promise 1 rejected"
 		reject(nil, errors.New("Promise 1 rejected"))
 	})
 
-	p2 = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p2 = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第二个 promise 被拒绝，原因是 "Promise 2 rejected"
 		reject(nil, errors.New("Promise 2 rejected"))
 	})
 
-	p3 = vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p3 = vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第三个 promise 被拒绝，原因是 "Promise 3 rejected"
 		reject(nil, errors.New("Promise 3 rejected"))
 	})

--- a/examples/case8/demo.go
+++ b/examples/case8/demo.go
@@ -9,17 +9,17 @@ import (
 
 func main() {
 	// 创建 3 个 promise
-	p1 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p1 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第一个 promise 直接解析为 "Promise 1"
 		resolve("Promise 1", nil)
 	})
 
-	p2 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p2 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第二个 promise 被拒绝，原因是 "Promise 2 rejected"
 		reject(nil, errors.New("Promise 2 rejected"))
 	})
 
-	p3 := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p3 := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 第三个 promise 直接解析为 "Promise 3"
 		resolve("Promise 3", nil)
 	})
@@ -28,7 +28,7 @@ func main() {
 	result := vl.AllSettled(p1, p2, p3)
 
 	// 从 promise 中获取所有的结果
-	for i, r := range result.GetValue().([]interface{}) {
+	for i, r := range result.GetValue().([]any) {
 		// 如果结果是一个错误，打印错误信息
 		if v, ok := r.(error); ok {
 			fmt.Println("!!", i, v.Error())

--- a/examples/case9/demo.go
+++ b/examples/case9/demo.go
@@ -10,39 +10,39 @@ import (
 func main() {
 
 	// 创建一个新的 Promise
-	result := vl.NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	result := vl.NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		// 这个 Promise 会立即被拒绝，原因是 "rejected.100"
 		reject(nil, fmt.Errorf("rejected.100"))
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 1")
 
 		// 返回一个新的错误，将会被下一个 Catch 函数接收
 		return nil, err
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当上一个 Catch 函数返回错误时，会执行这个 Catch 函数
 		fmt.Println("> catch 2")
 
 		// 返回一个新的错误，将会被下一个 Catch 函数接收
 		return nil, errors.New("rejected.200")
 
-	}).Catch(func(err error) (interface{}, error) {
+	}).Catch(func(err error) (any, error) {
 		// 当上一个 Catch 函数返回错误时，会执行这个 Catch 函数
 		fmt.Println("> catch 3")
 
 		// 返回一个新的错误，将会被下一个 Catch 函数接收
 		return nil, errors.New("rejected.300")
 
-	}).Then(func(value interface{}) (interface{}, error) {
+	}).Then(func(value any) (any, error) {
 		// 当 Promise 被解决时，会执行这个 Then 函数
 		fmt.Println("> then 1")
 
 		// 返回一个新的值，将会被下一个 Then 函数接收
 		return fmt.Sprintf("Never be here!! recover value: %v", value), nil
 
-	}, func(err error) (interface{}, error) {
+	}, func(err error) (any, error) {
 		// 当 Promise 被拒绝时，会执行这个 Catch 函数
 		fmt.Println("> catch 4")
 

--- a/promise.go
+++ b/promise.go
@@ -5,27 +5,32 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // PromiseState 表示 Promise 的状态
 type PromiseState uint8
 
 // Promise 操作的默认处理函数（不可变）
-func defaultSuccessHandler(value interface{}) (interface{}, error) { return value, nil }
-func defaultErrorHandler(err error) (interface{}, error)           { return nil, err }
-func defaultCleanupHandler() error                                 { return nil }
+func defaultSuccessHandler(value any) (any, error) { return value, nil }
+func defaultErrorHandler(err error) (any, error)   { return nil, err }
+func defaultCleanupHandler() error                 { return nil }
 
 // AggregateError 表示错误集合
 type AggregateError struct {
 	Errors []error
-	// 缓存 Error() 的结果，避免每次调用时重新拼接字符串和分配切片
-	cached string
+	// 缓存 Error() 的结果，避免每次调用时重新拼接字符串和分配切片。
+	// 使用 atomic.Pointer 保证并发调用 Error()/InvalidateError() 时
+	// 对缓存的读写不产生数据竞争（竞争下重复构建结果无害）。
+	// 注意：Errors 切片自身的并发修改仍需调用方同步；
+	// 库内部用法（Any）在结算前完成全部写入，结算后只读。
+	cached atomic.Pointer[string]
 }
 
 func (ae *AggregateError) Error() string {
 	// 如果有缓存且 Errors 未变更，直接返回
-	if ae.cached != "" {
-		return ae.cached
+	if cached := ae.cached.Load(); cached != nil {
+		return *cached
 	}
 
 	if len(ae.Errors) == 0 {
@@ -41,13 +46,13 @@ func (ae *AggregateError) Error() string {
 		errStrings = append(errStrings, err.Error())
 	}
 	result := "All promises were rejected: " + strings.Join(errStrings, ", ")
-	ae.cached = result
+	ae.cached.Store(&result)
 	return result
 }
 
 // InvalidateError 清除 Error() 的缓存，应在 Errors 被修改后调用
 func (ae *AggregateError) InvalidateError() {
-	ae.cached = ""
+	ae.cached.Store(nil)
 }
 
 func NewAggregateError(capacity int) *AggregateError {
@@ -79,56 +84,45 @@ func (s PromiseState) String() string {
 
 // subscriber 注册 Pending 状态 Promise 的回调
 type subscriber struct {
-	onFulfilled func(interface{}) (interface{}, error)
-	onRejected  func(error) (interface{}, error)
-	resolve     func(interface{}, error)
-	reject      func(interface{}, error)
+	onFulfilled        func(any) (any, error)
+	onRejected         func(error) (any, error)
+	resolve            func(any, error)
+	reject             func(any, error)
+	onFulfilledIndexed func(int, any) (any, error)
+	onRejectedIndexed  func(int, error) (any, error)
+	index              int
 }
 
 // noopSettle 是一个空操作的决议函数，用作直接 subscriber 的 resolve/reject 占位符。
 // 直接 subscriber 在 onFulfilled/onRejected 回调内部直接处理决议逻辑，
 // 因此 resolve/reject 字段仅为满足 dispatchCallback 的接口要求。
-func noopSettle(interface{}, error) {}
+func noopSettle(any, error) {}
 
 // Promise 表示一个异步操作
 type Promise struct {
 	mu          sync.RWMutex
 	state       PromiseState
-	value       interface{}
+	value       any
 	reason      error
 	subscribers []subscriber
 }
 
-// closurePair 持有预绑定的 resolve/reject 闭包
-// 通过 sync.Pool 复用，避免每次 NewPromise 调用时
-// 因 p.resolve / p.reject 方法值而产生的 2 次堆分配。
-type closurePair struct {
-	target  *Promise
-	resolve func(interface{}, error)
-	reject  func(interface{}, error)
-}
-
-var closurePairPool = sync.Pool{
-	New: func() interface{} {
-		cp := &closurePair{}
-		cp.resolve = func(value interface{}, reason error) {
-			cp.target.settle(Fulfilled, value, reason)
-		}
-		cp.reject = func(value interface{}, reason error) {
-			cp.target.settle(Rejected, value, reason)
-		}
-		return cp
-	},
-}
-
 // dispatchSubscriber 分派单个 subscriber，包含 panic 保护。
 // 提取为命名函数避免在 settle 循环中重复创建闭包。
-func dispatchSubscriber(sub subscriber, state PromiseState, value interface{}, reason error) {
+func dispatchSubscriber(sub *subscriber, state PromiseState, value any, reason error) {
 	defer func() {
 		if r := recover(); r != nil {
 			sub.reject(nil, fmt.Errorf("subscriber callback panic: %v", r))
 		}
 	}()
+	if sub.onFulfilledIndexed != nil {
+		if state == Rejected || reason != nil {
+			sub.onRejectedIndexed(sub.index, reason)
+		} else {
+			sub.onFulfilledIndexed(sub.index, value)
+		}
+		return
+	}
 	dispatchCallback(state, value, reason, sub.onFulfilled, sub.onRejected, sub.resolve, sub.reject)
 }
 
@@ -136,13 +130,13 @@ func dispatchSubscriber(sub subscriber, state PromiseState, value interface{}, r
 // 然后根据处理结果决议下游 Promise。
 // 此函数提取了 settle() 和 Then() 中重复的回调分发逻辑。
 func dispatchCallback(
-	state PromiseState, value interface{}, reason error,
-	onSuccess func(interface{}) (interface{}, error),
-	onError func(error) (interface{}, error),
-	resolve func(interface{}, error),
-	reject func(interface{}, error),
+	state PromiseState, value any, reason error,
+	onSuccess func(any) (any, error),
+	onError func(error) (any, error),
+	resolve func(any, error),
+	reject func(any, error),
 ) {
-	var v interface{}
+	var v any
 	var e error
 
 	if state == Rejected {
@@ -165,14 +159,14 @@ func dispatchCallback(
 // 用于 All/AllSettled 等需要按索引存储结果到共享切片的场景。
 // 包含 panic 保护，直接 subscriber 的 panic 会被吞没（不影响外层 Promise）。
 func dispatchIndexedCallback(
-	index int, state PromiseState, value interface{}, reason error,
-	onFulfilled func(int, interface{}) (interface{}, error),
-	onRejected func(int, error) (interface{}, error),
+	index int, state PromiseState, value any, reason error,
+	onFulfilled func(int, any) (any, error),
+	onRejected func(int, error) (any, error),
 ) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Panic in direct subscriber callback - swallowed to prevent cascade
-			_ = fmt.Errorf("subscriber callback panic: %v", r)
+			_ = r
 		}
 	}()
 	if state == Rejected {
@@ -189,7 +183,7 @@ func dispatchIndexedCallback(
 // 注意：subscriber 回调在调用者的 goroutine 中同步顺序执行。
 // 回调函数中不应包含阻塞操作（如死循环、I/O 等待），否则后续
 // subscriber 将被阻塞。如需异步处理，请在回调中启动 goroutine。
-func (p *Promise) settle(state PromiseState, value interface{}, reason error) {
+func (p *Promise) settle(state PromiseState, value any, reason error) {
 	p.mu.Lock()
 	if p.state != Pending {
 		p.mu.Unlock()
@@ -204,12 +198,12 @@ func (p *Promise) settle(state PromiseState, value interface{}, reason error) {
 	subs := p.subscribers
 	p.subscribers = nil
 	p.mu.Unlock()
-	for _, sub := range subs {
-		dispatchSubscriber(sub, state, value, reason)
+	for i := range subs {
+		dispatchSubscriber(&subs[i], state, value, reason)
 	}
 }
 
-func (p *Promise) snapshot() (PromiseState, interface{}, error) {
+func (p *Promise) snapshot() (PromiseState, any, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -221,14 +215,6 @@ func (p *Promise) getState() PromiseState {
 	return state
 }
 
-func (p *Promise) resolve(value interface{}, reason error) {
-	p.settle(Fulfilled, value, reason)
-}
-
-func (p *Promise) reject(value interface{}, reason error) {
-	p.settle(Rejected, value, reason)
-}
-
 // subscribeDirect 直接在 Promise 上注册 subscriber，不创建中间 Promise。
 // 适用于 All/AllSettled/Any/Race 等内部聚合操作，可避免 .Then() 创建的
 // 中间 Promise 和 executor 闭包的堆分配。
@@ -236,8 +222,8 @@ func (p *Promise) reject(value interface{}, reason error) {
 // 同步路径（Promise 已 settle）：直接分发回调，无额外分配。
 // 异步路径（Promise 仍 Pending）：将回调存入 subscribers 列表，等 settle 时触发。
 func (p *Promise) subscribeDirect(
-	onFulfilled func(interface{}) (interface{}, error),
-	onRejected func(error) (interface{}, error),
+	onFulfilled func(any) (any, error),
+	onRejected func(error) (any, error),
 ) {
 	sub := subscriber{
 		onFulfilled: onFulfilled,
@@ -250,7 +236,7 @@ func (p *Promise) subscribeDirect(
 	if p.state != Pending {
 		s, v, r := p.state, p.value, p.reason
 		p.mu.Unlock()
-		dispatchSubscriber(sub, s, v, r)
+		dispatchSubscriber(&sub, s, v, r)
 		return
 	}
 	p.subscribers = append(p.subscribers, sub)
@@ -262,11 +248,11 @@ func (p *Promise) subscribeDirect(
 // 需要按索引存储结果到共享切片的场景。共享回调在循环外创建，仅分配 2 次。
 //
 // 同步路径：通过 dispatchIndexedCallback 直接调用共享回调（无 per-subscriber 闭包分配）。
-// 异步路径：为每个 subscriber 创建绑定索引的包装闭包（2 allocs/subscriber）。
+// 异步路径：回调与索引直接存入 subscriber 结构（无 per-subscriber 闭包分配）。
 func (p *Promise) subscribeDirectIndexed(
 	index int,
-	onFulfilled func(int, interface{}) (interface{}, error),
-	onRejected func(int, error) (interface{}, error),
+	onFulfilled func(int, any) (any, error),
+	onRejected func(int, error) (any, error),
 ) {
 	p.mu.Lock()
 	if p.state != Pending {
@@ -275,32 +261,27 @@ func (p *Promise) subscribeDirectIndexed(
 		dispatchIndexedCallback(index, s, v, r, onFulfilled, onRejected)
 		return
 	}
-	// 异步路径：为每个 subscriber 创建绑定索引的包装闭包
-	idx := index
 	p.subscribers = append(p.subscribers, subscriber{
-		onFulfilled: func(value interface{}) (interface{}, error) {
-			return onFulfilled(idx, value)
-		},
-		onRejected: func(reason error) (interface{}, error) {
-			return onRejected(idx, reason)
-		},
-		resolve: noopSettle,
-		reject:  noopSettle,
+		onFulfilledIndexed: onFulfilled,
+		onRejectedIndexed:  onRejected,
+		index:              index,
+		resolve:            noopSettle,
+		reject:             noopSettle,
 	})
 	p.mu.Unlock()
 }
 
 // NewPromise 使用给定的处理函数创建新的 Promise
 //
-// 性能优化：
-//   - 使用 closurePair sync.Pool 复用 resolve/reject 闭包，
-//     消除每次调用时方法值（method value）的堆分配。
+// 设计说明：
+//   - resolve/reject 为直接捕获 p 的内联闭包，每次调用产生 2 次
+//     闭包堆分配。这是有意的正确性代价：若复用池化闭包，handler
+//     保留 resolve/reject 引用并在结算后再次调用（合法用法）时，
+//     会决议被重绑定的其他 Promise，造成静默数据损坏。
 //   - 内层 func() 用于 panic recovery，其闭包和 defer 均由编译器
 //     在栈上分配（escape analysis 确认 "func literal does not escape"），
 //     不产生堆分配开销。
-//   - 仅在 Promise 已决议（同步执行路径）时将 closurePair
-//     归还到 Pool；异步路径的 closurePair 由 GC 回收。
-func NewPromise(promiseHandler func(resolve func(interface{}, error), reject func(interface{}, error))) (result *Promise) {
+func NewPromise(promiseHandler func(resolve func(any, error), reject func(any, error))) (result *Promise) {
 	if promiseHandler == nil {
 		return &Promise{
 			state:  Rejected,
@@ -311,10 +292,8 @@ func NewPromise(promiseHandler func(resolve func(interface{}, error), reject fun
 	p := &Promise{state: Pending}
 	result = p
 
-	// 从池中获取预绑定闭包对（首次调用由 Pool.New 分配，
-	// 后续调用从池中复用，无堆分配）
-	cp := closurePairPool.Get().(*closurePair)
-	cp.target = p
+	resolve := func(value any, reason error) { p.settle(Fulfilled, value, reason) }
+	reject := func(value any, reason error) { p.settle(Rejected, value, reason) }
 
 	// 内层 func() + defer 用于隔离 handler panic：
 	// 当 handler panic 时，内层 defer recover 后内层函数正常返回，
@@ -323,18 +302,11 @@ func NewPromise(promiseHandler func(resolve func(interface{}, error), reject fun
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				cp.target.settle(Rejected, nil, fmt.Errorf("promise executor panic: %v", r))
+				p.settle(Rejected, nil, fmt.Errorf("promise executor panic: %v", r))
 			}
 		}()
-		promiseHandler(cp.resolve, cp.reject)
+		promiseHandler(resolve, reject)
 	}()
-
-	// 仅当 Promise 已决议（通常意味着同步执行路径）时
-	// 才将 closurePair 归还到池。对于异步路径（Promise 仍
-	// 为 Pending），cp 仍被外部 goroutine 引用，不可归还。
-	if p.getState() != Pending {
-		closurePairPool.Put(cp)
-	}
 
 	return p
 }
@@ -342,7 +314,7 @@ func NewPromise(promiseHandler func(resolve func(interface{}, error), reject fun
 // Then 在 Promise 满足时调用 successHandler，拒绝时调用 errorHandler。
 // 若 handler 为 nil 则使用默认透传处理。
 // 返回一个新的 Promise，其状态和值由 handler 的返回值决定。
-func (p *Promise) Then(successHandler func(interface{}) (interface{}, error), errorHandler func(error) (interface{}, error)) *Promise {
+func (p *Promise) Then(successHandler func(any) (any, error), errorHandler func(error) (any, error)) *Promise {
 	if successHandler == nil {
 		successHandler = defaultSuccessHandler
 	}
@@ -350,7 +322,7 @@ func (p *Promise) Then(successHandler func(interface{}) (interface{}, error), er
 		errorHandler = defaultErrorHandler
 	}
 
-	return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		state, value, reason := p.snapshot()
 		switch state {
 		case Fulfilled, Rejected:
@@ -375,7 +347,7 @@ func (p *Promise) Then(successHandler func(interface{}) (interface{}, error), er
 }
 
 // Catch 在 Promise 被拒绝时调用 errorHandler，返回可恢复的新 Promise。
-func (p *Promise) Catch(errorHandler func(error) (interface{}, error)) *Promise {
+func (p *Promise) Catch(errorHandler func(error) (any, error)) *Promise {
 	return p.Then(nil, errorHandler)
 }
 
@@ -387,14 +359,14 @@ func (p *Promise) Finally(cleanupHandler func() error) *Promise {
 	}
 
 	return p.Then(
-		func(value interface{}) (interface{}, error) {
+		func(value any) (any, error) {
 			err := cleanupHandler()
 			if err != nil {
 				return nil, err
 			}
 			return value, nil
 		},
-		func(reason error) (interface{}, error) {
+		func(reason error) (any, error) {
 			err := cleanupHandler()
 			if err != nil {
 				return nil, errors.Join(reason, err)
@@ -405,7 +377,7 @@ func (p *Promise) Finally(cleanupHandler func() error) *Promise {
 }
 
 // GetValue 返回 Promise 的满足值。若 Promise 尚未完成则返回 nil（线程安全）。
-func (p *Promise) GetValue() interface{} {
+func (p *Promise) GetValue() any {
 	_, value, _ := p.snapshot()
 	return value
 }
@@ -435,45 +407,34 @@ func countNonNil(promises []*Promise) int {
 //   - 使用 subscribeDirectIndexed 消除中间 Promise 和 executor 闭包分配
 //   - 共享回调在循环外创建，同步路径仅需 2 次闭包分配（vs N×3 次）
 func All(promises ...*Promise) *Promise {
-	return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		count := countNonNil(promises)
 		if count == 0 {
-			resolve([]interface{}{}, nil)
+			resolve([]any{}, nil)
 			return
 		}
 
-		values := make([]interface{}, count)
-		pendingCount := count
-		isCompleted := false
-		var mu sync.Mutex
+		values := make([]any, count)
+		var pending atomic.Int32
+		var rejected atomic.Bool
+		pending.Store(int32(count))
+
+		// 内存序：每个回调先写 values[i]，再对同一原子计数器执行 Add(-1)（release 语义）；
+		// 观察到 Add 返回 0 的操作在顺序一致性总序中位于所有先前 Add 之后（acquire 语义），
+		// 因此可见全部 slot 写入；settle 幂等兜底。
 
 		// 共享回调在循环外创建（仅 2 次闭包分配，vs 循环内 N×2 次）
-		onFulfilled := func(i int, value interface{}) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
-			}
+		onFulfilled := func(i int, value any) (any, error) {
 			values[i] = value
-			pendingCount--
-			if pendingCount == 0 {
-				isCompleted = true
-				mu.Unlock()
+			if pending.Add(-1) == 0 {
 				resolve(values, nil)
-				return nil, nil
 			}
-			mu.Unlock()
 			return nil, nil
 		}
-		onRejected := func(_ int, reason error) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
+		onRejected := func(_ int, reason error) (any, error) {
+			if rejected.CompareAndSwap(false, true) {
+				reject(nil, reason)
 			}
-			isCompleted = true
-			mu.Unlock()
-			reject(nil, reason)
 			return nil, nil
 		}
 
@@ -495,40 +456,34 @@ func All(promises ...*Promise) *Promise {
 //   - 使用 subscribeDirectIndexed 消除中间 Promise 和 executor 闭包分配
 //   - 共享回调在循环外创建，同步路径仅需 2 次闭包分配（vs N×2 次）
 func AllSettled(promises ...*Promise) *Promise {
-	return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		count := countNonNil(promises)
 		if count == 0 {
-			resolve([]interface{}{}, nil)
+			resolve([]any{}, nil)
 			return
 		}
 
-		values := make([]interface{}, count)
-		pendingCount := count
-		var mu sync.Mutex
+		values := make([]any, count)
+		var pending atomic.Int32
+		pending.Store(int32(count))
+
+		// 内存序：每个回调先写 values[i]，再对同一原子计数器执行 Add(-1)（release 语义）；
+		// 观察到 Add 返回 0 的操作在顺序一致性总序中位于所有先前 Add 之后（acquire 语义），
+		// 因此可见全部 slot 写入；settle 幂等兜底。
 
 		// 共享回调在循环外创建（仅 2 次闭包分配）
-		onFulfilled := func(i int, value interface{}) (interface{}, error) {
-			mu.Lock()
+		onFulfilled := func(i int, value any) (any, error) {
 			values[i] = value
-			pendingCount--
-			if pendingCount == 0 {
-				mu.Unlock()
+			if pending.Add(-1) == 0 {
 				resolve(values, nil)
-				return nil, nil
 			}
-			mu.Unlock()
 			return nil, nil
 		}
-		onRejected := func(i int, reason error) (interface{}, error) {
-			mu.Lock()
+		onRejected := func(i int, reason error) (any, error) {
 			values[i] = reason
-			pendingCount--
-			if pendingCount == 0 {
-				mu.Unlock()
+			if pending.Add(-1) == 0 {
 				resolve(values, nil)
-				return nil, nil
 			}
-			mu.Unlock()
 			return nil, nil
 		}
 
@@ -548,10 +503,10 @@ func AllSettled(promises ...*Promise) *Promise {
 //
 // 性能优化：
 //   - 使用 countNonNil 原地遍历，避免 filterNilPromises 的切片分配
-//   - 使用 subscribeDirect 消除中间 Promise 和 executor 闭包分配
-//   - 共享回调在循环外创建（无需索引），同步路径仅需 2 次闭包分配
+//   - 使用 subscribeDirectIndexed 消除中间 Promise 和 executor 闭包分配
+//   - 共享回调在循环外创建，同步路径仅需 2 次闭包分配
 func Any(promises ...*Promise) *Promise {
-	return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		count := countNonNil(promises)
 		if count == 0 {
 			reject(nil, NewAggregateError(0))
@@ -559,44 +514,34 @@ func Any(promises ...*Promise) *Promise {
 		}
 
 		aggErr := NewAggregateError(count)
-		pendingCount := count
-		isCompleted := false
-		var mu sync.Mutex
+		aggErr.Errors = aggErr.Errors[:count]
+		var pending atomic.Int32
+		var done atomic.Bool
+		pending.Store(int32(count))
 
-		// 共享回调在循环外创建（无索引依赖，所有 promise 共享）
-		onFulfilled := func(value interface{}) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
+		// 共享回调在循环外创建（索引经参数传入，所有 promise 共享）
+		onFulfilled := func(_ int, value any) (any, error) {
+			if done.CompareAndSwap(false, true) {
+				resolve(value, nil)
 			}
-			isCompleted = true
-			mu.Unlock()
-			resolve(value, nil)
 			return nil, nil
 		}
-		onRejected := func(reason error) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
-			}
-			aggErr.Errors = append(aggErr.Errors, reason)
-			pendingCount--
-			if pendingCount == 0 {
-				mu.Unlock()
+		onRejected := func(i int, reason error) (any, error) {
+			aggErr.Errors[i] = reason
+			// 不变式：每个输入 Promise 恰好分派一次回调且仅走一个分支，pending.Add(-1)==0 ⟺ 全部输入均走 onRejected（含 resolve(value, err) 转拒分支，该分支同样只递减计数而不触碰 done）⟹ onFulfilled 从未运行 ⟹ done 必为 false，故此 CAS 可证冗余。
+			if pending.Add(-1) == 0 {
 				reject(nil, aggErr)
-				return nil, nil
 			}
-			mu.Unlock()
 			return nil, nil
 		}
 
+		nonNilIdx := 0
 		for _, promise := range promises {
 			if promise == nil {
 				continue
 			}
-			promise.subscribeDirect(onFulfilled, onRejected)
+			promise.subscribeDirectIndexed(nonNilIdx, onFulfilled, onRejected)
+			nonNilIdx++
 		}
 	})
 }
@@ -608,37 +553,26 @@ func Any(promises ...*Promise) *Promise {
 //   - 使用 subscribeDirect 消除中间 Promise 和 executor 闭包分配
 //   - 共享回调在循环外创建（无需索引），同步路径仅需 2 次闭包分配
 func Race(promises ...*Promise) *Promise {
-	return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		count := countNonNil(promises)
 		if count == 0 {
 			resolve(nil, nil)
 			return
 		}
 
-		isCompleted := false
-		var mu sync.Mutex
+		var done atomic.Bool
 
 		// 共享回调在循环外创建（无索引依赖，所有 promise 共享）
-		onFulfilled := func(value interface{}) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
+		onFulfilled := func(value any) (any, error) {
+			if done.CompareAndSwap(false, true) {
+				resolve(value, nil)
 			}
-			isCompleted = true
-			mu.Unlock()
-			resolve(value, nil)
 			return nil, nil
 		}
-		onRejected := func(reason error) (interface{}, error) {
-			mu.Lock()
-			if isCompleted {
-				mu.Unlock()
-				return nil, nil
+		onRejected := func(reason error) (any, error) {
+			if done.CompareAndSwap(false, true) {
+				reject(nil, reason)
 			}
-			isCompleted = true
-			mu.Unlock()
-			reject(nil, reason)
 			return nil, nil
 		}
 

--- a/promise_benchmark_test.go
+++ b/promise_benchmark_test.go
@@ -9,11 +9,11 @@ import (
 
 var benchmarkErr = errors.New("benchmark rejection")
 
-func benchmarkIncrement(value interface{}) (interface{}, error) {
+func benchmarkIncrement(value any) (any, error) {
 	return value.(int) + 1, nil
 }
 
-func benchmarkPropagateError(err error) (interface{}, error) {
+func benchmarkPropagateError(err error) (any, error) {
 	return nil, err
 }
 
@@ -24,9 +24,8 @@ func benchmarkCleanupNoop() error {
 func makeFulfilledPromises(size int) []*Promise {
 	promises := make([]*Promise, size)
 	for i := 0; i < size; i++ {
-		value := i
-		promises[i] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
-			resolve(value, nil)
+		promises[i] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
+			resolve(i, nil)
 		})
 	}
 	return promises
@@ -35,7 +34,7 @@ func makeFulfilledPromises(size int) []*Promise {
 func makeRejectedPromises(size int, err error) []*Promise {
 	promises := make([]*Promise, size)
 	for i := 0; i < size; i++ {
-		promises[i] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		promises[i] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, err)
 		})
 	}
@@ -46,13 +45,12 @@ func makeMixedPromises(size int, err error) []*Promise {
 	promises := make([]*Promise, size)
 	for i := 0; i < size; i++ {
 		if i%2 == 0 {
-			value := i
-			promises[i] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
-				resolve(value, nil)
+			promises[i] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
+				resolve(i, nil)
 			})
 			continue
 		}
-		promises[i] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		promises[i] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, err)
 		})
 	}
@@ -65,12 +63,12 @@ func makeRacePromises(size int, err error) []*Promise {
 		return promises
 	}
 
-	promises[0] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	promises[0] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		resolve("winner", nil)
 	})
 
 	for i := 1; i < size; i++ {
-		promises[i] = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		promises[i] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, err)
 		})
 	}
@@ -80,11 +78,10 @@ func makeRacePromises(size int, err error) []*Promise {
 
 func BenchmarkPromiseThenChain(b *testing.B) {
 	for _, chainLength := range []int{1, 8, 32} {
-		chainLength := chainLength
 		b.Run(fmt.Sprintf("chain=%d", chainLength), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+				p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 					resolve(0, nil)
 				})
 				for j := 0; j < chainLength; j++ {
@@ -104,11 +101,10 @@ func BenchmarkPromiseThenChain(b *testing.B) {
 
 func BenchmarkPromiseCatchChain(b *testing.B) {
 	for _, chainLength := range []int{1, 8, 32} {
-		chainLength := chainLength
 		b.Run(fmt.Sprintf("chain=%d", chainLength), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+				p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 					reject(nil, benchmarkErr)
 				})
 				for j := 0; j < chainLength; j++ {
@@ -128,7 +124,7 @@ func BenchmarkPromiseCatchChain(b *testing.B) {
 func BenchmarkPromiseFinally(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("ok", nil)
 		}).Finally(benchmarkCleanupNoop)
 
@@ -140,7 +136,6 @@ func BenchmarkPromiseFinally(b *testing.B) {
 
 func BenchmarkPromiseAll(b *testing.B) {
 	for _, size := range []int{4, 32, 128} {
-		size := size
 		promises := makeFulfilledPromises(size)
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			b.ReportAllocs()
@@ -148,7 +143,7 @@ func BenchmarkPromiseAll(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				p := All(promises...)
 				if i == 0 {
-					values, ok := p.GetValue().([]interface{})
+					values, ok := p.GetValue().([]any)
 					if !ok || p.GetReason() != nil || len(values) != size {
 						b.Fatalf("unexpected All result: value=%v reason=%v", p.GetValue(), p.GetReason())
 					}
@@ -160,7 +155,6 @@ func BenchmarkPromiseAll(b *testing.B) {
 
 func BenchmarkPromiseAllSettled(b *testing.B) {
 	for _, size := range []int{4, 32, 128} {
-		size := size
 		promises := makeMixedPromises(size, benchmarkErr)
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			b.ReportAllocs()
@@ -168,7 +162,7 @@ func BenchmarkPromiseAllSettled(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				p := AllSettled(promises...)
 				if i == 0 {
-					values, ok := p.GetValue().([]interface{})
+					values, ok := p.GetValue().([]any)
 					if !ok || p.GetReason() != nil || len(values) != size {
 						b.Fatalf("unexpected AllSettled result: value=%v reason=%v", p.GetValue(), p.GetReason())
 					}
@@ -211,7 +205,6 @@ func BenchmarkPromiseAny(b *testing.B) {
 
 func BenchmarkPromiseRace(b *testing.B) {
 	for _, size := range []int{4, 32, 128} {
-		size := size
 		promises := makeRacePromises(size, benchmarkErr)
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			b.ReportAllocs()
@@ -228,14 +221,25 @@ func BenchmarkPromiseRace(b *testing.B) {
 
 func BenchmarkAggregateError(b *testing.B) {
 	for _, size := range []int{1, 8, 64} {
-		size := size
-		aggregateErr := NewAggregateError(size)
-		for i := 0; i < size; i++ {
-			aggregateErr.Errors = append(aggregateErr.Errors, errors.New(fmt.Sprintf("error-%d", i)))
-		}
-
-		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+		b.Run(fmt.Sprintf("build/size=%d", size), func(b *testing.B) {
 			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				aggregateErr := NewAggregateError(size)
+				for j := 0; j < size; j++ {
+					aggregateErr.Errors = append(aggregateErr.Errors, errors.New(fmt.Sprintf("error-%d", j)))
+				}
+				_ = aggregateErr.Error()
+			}
+		})
+
+		b.Run(fmt.Sprintf("cached/size=%d", size), func(b *testing.B) {
+			aggregateErr := NewAggregateError(size)
+			for j := 0; j < size; j++ {
+				aggregateErr.Errors = append(aggregateErr.Errors, errors.New(fmt.Sprintf("error-%d", j)))
+			}
+			_ = aggregateErr.Error()
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = aggregateErr.Error()
 			}
@@ -249,7 +253,7 @@ func BenchmarkPromiseConcurrentSettle(b *testing.B) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			go func() {
 				defer wg.Done()
 				resolve("ok", nil)
@@ -264,5 +268,58 @@ func BenchmarkPromiseConcurrentSettle(b *testing.B) {
 		_ = p.getState()
 		_ = p.GetValue()
 		_ = p.GetReason()
+	}
+}
+
+func BenchmarkPromiseThenPending(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var asyncResolve func(any, error)
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
+			asyncResolve = resolve
+		})
+		result := p.Then(benchmarkIncrement, nil)
+		asyncResolve(0, nil)
+
+		if i == 0 {
+			finalValue, ok := result.GetValue().(int)
+			if !ok || finalValue != 1 || result.GetReason() != nil {
+				b.Fatalf("unexpected pending Then result: value=%v reason=%v", result.GetValue(), result.GetReason())
+			}
+		}
+	}
+}
+
+func BenchmarkPromiseAllPending(b *testing.B) {
+	for _, size := range []int{4, 32, 128} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				promises := make([]*Promise, size)
+				resolvers := make([]func(any, error), size)
+				for j := 0; j < size; j++ {
+					promises[j] = NewPromise(func(resolve func(any, error), reject func(any, error)) {
+						resolvers[j] = resolve
+					})
+				}
+
+				p := All(promises...)
+				for j := 0; j < size; j++ {
+					resolvers[j](j, nil)
+				}
+
+				if i == 0 {
+					values, ok := p.GetValue().([]any)
+					if !ok || p.GetReason() != nil || len(values) != size {
+						b.Fatalf("unexpected pending All result: value=%v reason=%v", p.GetValue(), p.GetReason())
+					}
+					for j := 0; j < size; j++ {
+						if values[j] != j {
+							b.Fatalf("unexpected pending All value at index %d: %v", j, values[j])
+						}
+					}
+				}
+			}
+		})
 	}
 }

--- a/promise_test.go
+++ b/promise_test.go
@@ -13,11 +13,11 @@ import (
 
 func TestPromise_Then(t *testing.T) {
 	t.Run("Fulfilled state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
+		result := p.Then(func(value any) (any, error) {
 			return value.(string) + " vowlink", nil
 		}, nil)
 
@@ -26,11 +26,11 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("Rejected state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
 		})
 
-		result := p.Then(nil, func(reason error) (interface{}, error) {
+		result := p.Then(nil, func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -39,7 +39,7 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("Nil onFulfilled and onRejected", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
@@ -50,13 +50,13 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("Then Chain", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
+		result := p.Then(func(value any) (any, error) {
 			return value.(string) + " vowlink", nil
-		}, nil).Then(func(value interface{}) (interface{}, error) {
+		}, nil).Then(func(value any) (any, error) {
 			return value.(string) + "!", nil
 		}, nil)
 
@@ -66,15 +66,15 @@ func TestPromise_Then(t *testing.T) {
 
 	// 当.then中返回的不是promise对象时（包括undefined），p2的状态一直都是fulfilled，且值为undefined
 	t.Run("Then Chain with Rejection", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
+		result := p.Then(func(value any) (any, error) {
 			return value.(string) + " vowlink", nil
-		}, nil).Then(func(value interface{}) (interface{}, error) {
+		}, nil).Then(func(value any) (any, error) {
 			return value.(string) + "!", nil
-		}, func(reason error) (interface{}, error) {
+		}, func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -83,12 +83,12 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("Then return a Promise with resolve", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
-			return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		result := p.Then(func(value any) (any, error) {
+			return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 				resolve(value.(string)+" vowlink", nil)
 			}), nil
 		}, nil)
@@ -98,12 +98,12 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("Then return a Promise with reject", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
-			return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		result := p.Then(func(value any) (any, error) {
+			return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 				reject(nil, errors.New("Something went wrong"))
 			}), nil
 		}, nil)
@@ -114,15 +114,15 @@ func TestPromise_Then(t *testing.T) {
 	})
 
 	t.Run("One Then onRejected after Then return a Promise with reject", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Then(func(value interface{}) (interface{}, error) {
-			return NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		result := p.Then(func(value any) (any, error) {
+			return NewPromise(func(resolve func(any, error), reject func(any, error)) {
 				reject(nil, errors.New("Something went wrong"))
 			}), nil
-		}, nil).Then(nil, func(reason error) (interface{}, error) {
+		}, nil).Then(nil, func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -133,11 +133,11 @@ func TestPromise_Then(t *testing.T) {
 
 func TestPromise_Catch(t *testing.T) {
 	t.Run("Fulfilled state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
-		result := p.Catch(func(reason error) (interface{}, error) {
+		result := p.Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -146,11 +146,11 @@ func TestPromise_Catch(t *testing.T) {
 	})
 
 	t.Run("Rejected state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
 		})
 
-		result := p.Catch(func(reason error) (interface{}, error) {
+		result := p.Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -159,7 +159,7 @@ func TestPromise_Catch(t *testing.T) {
 	})
 
 	t.Run("Nil onRejected", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
 		})
 
@@ -172,7 +172,7 @@ func TestPromise_Catch(t *testing.T) {
 
 func TestPromise_Finally(t *testing.T) {
 	t.Run("Fulfilled state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
@@ -188,7 +188,7 @@ func TestPromise_Finally(t *testing.T) {
 	})
 
 	t.Run("Rejected state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
 		})
 
@@ -204,7 +204,7 @@ func TestPromise_Finally(t *testing.T) {
 	})
 
 	t.Run("Nil onFinally", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		})
 
@@ -217,34 +217,34 @@ func TestPromise_Finally(t *testing.T) {
 
 func TestMethod_All(t *testing.T) {
 	t.Run("All promises fulfilled", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 2", nil)
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
 		result := All(p1, p2, p3)
 
 		assert.Equal(t, Fulfilled, result.state, "Expected state to be Fulfilled")
-		assert.Equal(t, []interface{}{"Promise 1", "Promise 2", "Promise 3"}, result.value, "Expected value to be ['Promise 1', 'Promise 2', 'Promise 3']")
+		assert.Equal(t, []any{"Promise 1", "Promise 2", "Promise 3"}, result.value, "Expected value to be ['Promise 1', 'Promise 2', 'Promise 3']")
 	})
 
 	t.Run("One promise rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
@@ -255,15 +255,15 @@ func TestMethod_All(t *testing.T) {
 	})
 
 	t.Run("All promises rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 1 rejected"))
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 3 rejected"))
 		})
 
@@ -276,15 +276,15 @@ func TestMethod_All(t *testing.T) {
 
 func TestPromise_Any(t *testing.T) {
 	t.Run("Any promises fulfilled", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 2", nil)
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
@@ -295,15 +295,15 @@ func TestPromise_Any(t *testing.T) {
 	})
 
 	t.Run("One promise rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
@@ -314,15 +314,15 @@ func TestPromise_Any(t *testing.T) {
 	})
 
 	t.Run("All promises rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 1 rejected"))
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 3 rejected"))
 		})
 
@@ -340,15 +340,15 @@ func TestPromise_Any(t *testing.T) {
 
 func TestPromise_Race(t *testing.T) {
 	t.Run("One promise fulfilled", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 2", nil)
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
@@ -359,15 +359,15 @@ func TestPromise_Race(t *testing.T) {
 	})
 
 	t.Run("One promise rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 1 rejected"))
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 2", nil)
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
@@ -378,15 +378,15 @@ func TestPromise_Race(t *testing.T) {
 	})
 
 	t.Run("All promises rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 1 rejected"))
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 3 rejected"))
 		})
 
@@ -399,72 +399,72 @@ func TestPromise_Race(t *testing.T) {
 
 func TestPromise_AllSettled(t *testing.T) {
 	t.Run("All promises fulfilled", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 2", nil)
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
 		result := AllSettled(p1, p2, p3)
 
 		assert.Equal(t, Fulfilled, result.state, "Expected state to be Fulfilled")
-		assert.Equal(t, []interface{}{"Promise 1", "Promise 2", "Promise 3"}, result.value, "Expected value to be ['Promise 1', 'Promise 2', 'Promise 3']")
+		assert.Equal(t, []any{"Promise 1", "Promise 2", "Promise 3"}, result.value, "Expected value to be ['Promise 1', 'Promise 2', 'Promise 3']")
 	})
 
 	t.Run("One promise rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 1", nil)
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Promise 3", nil)
 		})
 
 		result := AllSettled(p1, p2, p3)
 
 		assert.Equal(t, Fulfilled, result.state, "Expected state to be Fulfilled")
-		assert.Equal(t, []interface{}{"Promise 1", errors.New("Promise 2 rejected"), "Promise 3"}, result.value, "Expected value to be ['Promise 1', errors.New('Promise 2 rejected'), 'Promise 3']")
+		assert.Equal(t, []any{"Promise 1", errors.New("Promise 2 rejected"), "Promise 3"}, result.value, "Expected value to be ['Promise 1', errors.New('Promise 2 rejected'), 'Promise 3']")
 	})
 
 	t.Run("All promises rejected", func(t *testing.T) {
-		p1 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 1 rejected"))
 		})
 
-		p2 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 2 rejected"))
 		})
 
-		p3 := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Promise 3 rejected"))
 		})
 
 		result := AllSettled(p1, p2, p3)
 
 		assert.Equal(t, Fulfilled, result.state, "Expected state to be Fulfilled")
-		assert.Equal(t, []interface{}{errors.New("Promise 1 rejected"), errors.New("Promise 2 rejected"), errors.New("Promise 3 rejected")}, result.value, "Expected value to be [errors.New('Promise 1 rejected'), errors.New('Promise 2 rejected'), errors.New('Promise 3 rejected')]")
+		assert.Equal(t, []any{errors.New("Promise 1 rejected"), errors.New("Promise 2 rejected"), errors.New("Promise 3 rejected")}, result.value, "Expected value to be [errors.New('Promise 1 rejected'), errors.New('Promise 2 rejected'), errors.New('Promise 3 rejected')]")
 	})
 }
 
 func TestPromise_MultiCatch(t *testing.T) {
 	t.Run("Rejected Multi Catch with New Error", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 1 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 2 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 3 error: " + reason.Error())
 		})
 
@@ -473,13 +473,13 @@ func TestPromise_MultiCatch(t *testing.T) {
 	})
 
 	t.Run("Rejected Multi Catch with Recover and Return Value", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 1 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return "Recovered value", nil
-		}).Then(func(data interface{}) (interface{}, error) {
+		}).Then(func(data any) (any, error) {
 			return data, nil
 		}, nil)
 
@@ -488,15 +488,15 @@ func TestPromise_MultiCatch(t *testing.T) {
 	})
 
 	t.Run("Rejected Multi Catch with Recover and Then return error", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 1 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return "Recovered value", nil
-		}).Then(func(data interface{}) (interface{}, error) {
+		}).Then(func(data any) (any, error) {
 			return nil, errors.New("Then error: " + data.(string))
-		}, nil).Catch(func(reason error) (interface{}, error) {
+		}, nil).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 2 error: " + reason.Error())
 		})
 
@@ -505,16 +505,16 @@ func TestPromise_MultiCatch(t *testing.T) {
 	})
 
 	t.Run("Rejected Multi Catch with New Error and Finally", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 1 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 2 error: " + reason.Error())
 		}).Finally(func() error {
 			fmt.Println("Finally called")
 			return nil
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 3 error: " + reason.Error())
 		})
 
@@ -523,16 +523,16 @@ func TestPromise_MultiCatch(t *testing.T) {
 	})
 
 	t.Run("Rejected Multi Catch with Recover and Finally", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return nil, errors.New("Handled 1 error: " + reason.Error())
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return "Recovered value", nil
 		}).Finally(func() error {
 			fmt.Println("Finally called")
 			return nil
-		}).Then(func(data interface{}) (interface{}, error) {
+		}).Then(func(data any) (any, error) {
 			return data, nil
 		}, nil)
 
@@ -542,16 +542,16 @@ func TestPromise_MultiCatch(t *testing.T) {
 }
 
 func TestPromise_ResolveWithError(t *testing.T) {
-	p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		resolve(nil, errors.New("Something went wrong"))
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		return nil, errors.New("Handled error: " + reason.Error())
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		return "Recovered value", nil
 	}).Finally(func() error {
 		fmt.Println("Finally called")
 		return nil
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		return data, nil
 	}, nil)
 
@@ -560,13 +560,13 @@ func TestPromise_ResolveWithError(t *testing.T) {
 }
 
 func TestPromise_ResolveWithErrorData(t *testing.T) {
-	p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		resolve(errors.New("Something went wrong"), nil)
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		return data.(error).Error(), nil
-	}, func(error) (interface{}, error) {
+	}, func(error) (any, error) {
 		return nil, errors.New("Handled error")
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		return fmt.Sprintf("Recovered value: %v", reason.Error()), nil
 	})
 
@@ -575,13 +575,13 @@ func TestPromise_ResolveWithErrorData(t *testing.T) {
 }
 
 func TestPromise_RejectWithNil(t *testing.T) {
-	p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+	p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 		reject("Something went wrong", nil)
-	}).Then(func(data interface{}) (interface{}, error) {
+	}).Then(func(data any) (any, error) {
 		return data, nil
-	}, func(error) (interface{}, error) {
+	}, func(error) (any, error) {
 		return nil, errors.New("Handled error")
-	}).Catch(func(reason error) (interface{}, error) {
+	}).Catch(func(reason error) (any, error) {
 		return fmt.Sprintf("Recovered value: %v", reason.Error()), nil
 	})
 
@@ -591,13 +591,13 @@ func TestPromise_RejectWithNil(t *testing.T) {
 
 func TestPromise_FinallyWithError(t *testing.T) {
 	t.Run("Finally with error and resolved", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("Hello, World!", nil)
 		}).Finally(func() error {
 			return errors.New("Finally error")
-		}).Then(func(data interface{}) (interface{}, error) {
+		}).Then(func(data any) (any, error) {
 			return data.(string) + " vowlink", nil
-		}, func(reason error) (interface{}, error) {
+		}, func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -607,13 +607,13 @@ func TestPromise_FinallyWithError(t *testing.T) {
 	})
 
 	t.Run("Finally with error and rejected", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("Something went wrong"))
 		}).Finally(func() error {
 			return errors.New("Finally error")
-		}).Then(func(data interface{}) (interface{}, error) {
+		}).Then(func(data any) (any, error) {
 			return data.(string) + " vowlink", nil
-		}, func(reason error) (interface{}, error) {
+		}, func(reason error) (any, error) {
 			return nil, errors.New("Handled error: " + reason.Error())
 		})
 
@@ -632,7 +632,7 @@ func TestNewPromise(t *testing.T) {
 	})
 
 	t.Run("initial state", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			// Empty handler
 		})
 		assert.Equal(t, Pending, p.state, "Expected initial state to be Pending")
@@ -646,7 +646,7 @@ func TestPromise_ConcurrentAccess(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			go func() {
 				defer wg.Done()
 				resolve("success", nil)
@@ -681,7 +681,7 @@ func TestPromise_NoGoroutineLeak(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(2)
 
-			_ = NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+			_ = NewPromise(func(resolve func(any, error), reject func(any, error)) {
 				go func() {
 					defer wg.Done()
 					resolve("ok", nil)
@@ -714,7 +714,7 @@ func TestPromise_NoGoroutineLeak(t *testing.T) {
 
 func TestPromise_StateImmutability(t *testing.T) {
 	t.Run("fulfilled state cannot be changed", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve("first", nil)
 			resolve("second", nil)           // should not change state
 			reject(nil, errors.New("error")) // should not change state
@@ -726,7 +726,7 @@ func TestPromise_StateImmutability(t *testing.T) {
 	})
 
 	t.Run("rejected state cannot be changed", func(t *testing.T) {
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			reject(nil, errors.New("first error"))
 			reject(nil, errors.New("second error")) // should not change state
 			resolve("success", nil)                 // should not change state
@@ -742,7 +742,7 @@ func TestPromise_EmptyArray(t *testing.T) {
 	t.Run("All with empty array", func(t *testing.T) {
 		result := All()
 		assert.Equal(t, Fulfilled, result.state)
-		assert.Equal(t, []interface{}{}, result.value)
+		assert.Equal(t, []any{}, result.value)
 	})
 
 	t.Run("Race with empty array", func(t *testing.T) {
@@ -760,7 +760,7 @@ func TestPromise_EmptyArray(t *testing.T) {
 	t.Run("AllSettled with empty array", func(t *testing.T) {
 		result := AllSettled()
 		assert.Equal(t, Fulfilled, result.state)
-		assert.Equal(t, []interface{}{}, result.value)
+		assert.Equal(t, []any{}, result.value)
 	})
 }
 
@@ -768,12 +768,12 @@ func TestPromise_AsyncThen(t *testing.T) {
 	t.Run("async resolve with Then chain", func(t *testing.T) {
 		done := make(chan struct{})
 		var result string
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				resolve("async", nil)
 			}()
 		})
-		p.Then(func(value interface{}) (interface{}, error) {
+		p.Then(func(value any) (any, error) {
 			result = value.(string) + " done"
 			close(done)
 			return nil, nil
@@ -789,12 +789,12 @@ func TestPromise_AsyncThen(t *testing.T) {
 	t.Run("async reject with Catch chain", func(t *testing.T) {
 		done := make(chan struct{})
 		var errMsg string
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				reject(nil, errors.New("async error"))
 			}()
 		})
-		p.Catch(func(reason error) (interface{}, error) {
+		p.Catch(func(reason error) (any, error) {
 			errMsg = reason.Error()
 			close(done)
 			return nil, nil
@@ -811,18 +811,18 @@ func TestPromise_AsyncThen(t *testing.T) {
 		done1 := make(chan struct{})
 		done2 := make(chan struct{})
 		var r1, r2 int
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				resolve(42, nil)
 			}()
 		})
-		p.Then(func(value interface{}) (interface{}, error) {
+		p.Then(func(value any) (any, error) {
 			r1 = value.(int) * 2
 			close(done1)
 			return nil, nil
 		}, nil)
-		p.Then(func(value interface{}) (interface{}, error) {
+		p.Then(func(value any) (any, error) {
 			r2 = value.(int) * 3
 			close(done2)
 			return nil, nil
@@ -845,26 +845,26 @@ func TestPromise_AsyncThen(t *testing.T) {
 func TestPromise_AsyncAll(t *testing.T) {
 	t.Run("async resolve collection with correct order", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				resolve("first", nil)
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				resolve("second", nil)
 			}()
 		})
-		p3 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(150 * time.Millisecond)
 				resolve("third", nil)
 			}()
 		})
 		result := All(p1, p2, p3)
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
 		}, nil)
@@ -874,7 +874,7 @@ func TestPromise_AsyncAll(t *testing.T) {
 			t.Fatal("timeout waiting for All async")
 		}
 		assert.Equal(t, Fulfilled, result.state)
-		values := result.value.([]interface{})
+		values := result.value.([]any)
 		assert.Equal(t, 3, len(values))
 		assert.Equal(t, "first", values[0])
 		assert.Equal(t, "second", values[1])
@@ -883,20 +883,20 @@ func TestPromise_AsyncAll(t *testing.T) {
 
 	t.Run("one async reject fails All", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				resolve("ok", nil)
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				reject(nil, errors.New("fast fail"))
 			}()
 		})
 		result := All(p1, p2)
-		result.Then(nil, func(reason error) (interface{}, error) {
+		result.Then(nil, func(reason error) (any, error) {
 			close(done)
 			return nil, nil
 		})
@@ -913,26 +913,26 @@ func TestPromise_AsyncAll(t *testing.T) {
 func TestPromise_AsyncRace(t *testing.T) {
 	t.Run("fastest resolve wins", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(200 * time.Millisecond)
 				resolve("slow", nil)
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(20 * time.Millisecond)
 				resolve("fast", nil)
 			}()
 		})
-		p3 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(300 * time.Millisecond)
 				resolve("slowest", nil)
 			}()
 		})
 		result := Race(p1, p2, p3)
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
 		}, nil)
@@ -947,20 +947,20 @@ func TestPromise_AsyncRace(t *testing.T) {
 
 	t.Run("fastest reject wins", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(200 * time.Millisecond)
 				resolve("slow", nil)
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(20 * time.Millisecond)
 				reject(nil, errors.New("fast error"))
 			}()
 		})
 		result := Race(p1, p2)
-		result.Then(nil, func(reason error) (interface{}, error) {
+		result.Then(nil, func(reason error) (any, error) {
 			close(done)
 			return nil, nil
 		})
@@ -977,26 +977,26 @@ func TestPromise_AsyncRace(t *testing.T) {
 func TestPromise_AsyncAny(t *testing.T) {
 	t.Run("first resolve wins among mixed", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				reject(nil, errors.New("err1"))
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				resolve("winner", nil)
 			}()
 		})
-		p3 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(150 * time.Millisecond)
 				resolve("loser", nil)
 			}()
 		})
 		result := Any(p1, p2, p3)
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
 		}, nil)
@@ -1011,20 +1011,20 @@ func TestPromise_AsyncAny(t *testing.T) {
 
 	t.Run("all async reject with AggregateError", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				reject(nil, errors.New("async err1"))
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				reject(nil, errors.New("async err2"))
 			}()
 		})
 		result := Any(p1, p2)
-		result.Then(nil, func(reason error) (interface{}, error) {
+		result.Then(nil, func(reason error) (any, error) {
 			close(done)
 			return nil, nil
 		})
@@ -1043,26 +1043,26 @@ func TestPromise_AsyncAny(t *testing.T) {
 func TestPromise_AsyncAllSettled(t *testing.T) {
 	t.Run("mixed async resolve and reject", func(t *testing.T) {
 		done := make(chan struct{})
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				resolve("a", nil)
 			}()
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				reject(nil, errors.New("err b"))
 			}()
 		})
-		p3 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p3 := NewPromise(func(resolve, reject func(any, error)) {
 			go func() {
 				time.Sleep(150 * time.Millisecond)
 				resolve("c", nil)
 			}()
 		})
 		result := AllSettled(p1, p2, p3)
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
 		}, nil)
@@ -1072,7 +1072,7 @@ func TestPromise_AsyncAllSettled(t *testing.T) {
 			t.Fatal("timeout waiting for AllSettled")
 		}
 		assert.Equal(t, Fulfilled, result.state)
-		values := result.value.([]interface{})
+		values := result.value.([]any)
 		assert.Equal(t, 3, len(values))
 		assert.Equal(t, "a", values[0])
 		assert.EqualError(t, errors.New("err b"), values[1].(error).Error())
@@ -1082,15 +1082,15 @@ func TestPromise_AsyncAllSettled(t *testing.T) {
 
 func TestPromise_NilPromise(t *testing.T) {
 	t.Run("All with nil in middle", func(t *testing.T) {
-		p1 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
 			resolve("a", nil)
 		})
-		p2 := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
 			resolve("b", nil)
 		})
 		result := All(p1, nil, p2)
 		assert.Equal(t, Fulfilled, result.state)
-		values := result.value.([]interface{})
+		values := result.value.([]any)
 		assert.Equal(t, 2, len(values))
 		assert.Equal(t, "a", values[0])
 		assert.Equal(t, "b", values[1])
@@ -1099,13 +1099,13 @@ func TestPromise_NilPromise(t *testing.T) {
 	t.Run("All with only nil", func(t *testing.T) {
 		result := All(nil)
 		assert.Equal(t, Fulfilled, result.state)
-		assert.Equal(t, []interface{}{}, result.value)
+		assert.Equal(t, []any{}, result.value)
 	})
 
 	t.Run("AllSettled with nil nil", func(t *testing.T) {
 		result := AllSettled(nil, nil)
 		assert.Equal(t, Fulfilled, result.state)
-		assert.Equal(t, []interface{}{}, result.value)
+		assert.Equal(t, []any{}, result.value)
 	})
 
 	t.Run("Any with nil nil", func(t *testing.T) {
@@ -1128,21 +1128,20 @@ func TestPromise_ConcurrentAll(t *testing.T) {
 		var wg sync.WaitGroup
 		for i := 0; i < n; i++ {
 			wg.Add(1)
-			idx := i
-			promises[i] = NewPromise(func(resolve, reject func(interface{}, error)) {
+			promises[i] = NewPromise(func(resolve, reject func(any, error)) {
 				go func() {
 					defer wg.Done()
-					time.Sleep(time.Duration(idx%10) * time.Millisecond)
-					resolve(idx, nil)
+					time.Sleep(time.Duration(i%10) * time.Millisecond)
+					resolve(i, nil)
 				}()
 			})
 		}
 		result := All(promises...)
 		done := make(chan struct{})
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
-		}, func(reason error) (interface{}, error) {
+		}, func(reason error) (any, error) {
 			close(done)
 			return nil, nil
 		})
@@ -1153,7 +1152,7 @@ func TestPromise_ConcurrentAll(t *testing.T) {
 			t.Fatal("timeout waiting for large All")
 		}
 		assert.Equal(t, Fulfilled, result.state)
-		values := result.value.([]interface{})
+		values := result.value.([]any)
 		assert.Equal(t, n, len(values))
 		for i := 0; i < n; i++ {
 			assert.Equal(t, i, values[i].(int))
@@ -1164,24 +1163,23 @@ func TestPromise_ConcurrentAll(t *testing.T) {
 		const n = 200
 		promises := make([]*Promise, n)
 		for i := 0; i < n; i++ {
-			idx := i
-			promises[i] = NewPromise(func(resolve, reject func(interface{}, error)) {
+			promises[i] = NewPromise(func(resolve, reject func(any, error)) {
 				go func() {
-					time.Sleep(time.Duration(idx%5) * time.Millisecond)
-					if idx%7 == 0 {
+					time.Sleep(time.Duration(i%5) * time.Millisecond)
+					if i%7 == 0 {
 						reject(nil, errors.New("err"))
 					} else {
-						resolve(idx, nil)
+						resolve(i, nil)
 					}
 				}()
 			})
 		}
 		result := All(promises...)
 		done := make(chan struct{})
-		result.Then(func(value interface{}) (interface{}, error) {
+		result.Then(func(value any) (any, error) {
 			close(done)
 			return nil, nil
-		}, func(reason error) (interface{}, error) {
+		}, func(reason error) (any, error) {
 			close(done)
 			return nil, nil
 		})
@@ -1196,7 +1194,7 @@ func TestPromise_ConcurrentAll(t *testing.T) {
 
 func TestPromise_ExecutorPanic(t *testing.T) {
 	t.Run("executor panic recovers to rejected", func(t *testing.T) {
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			panic("executor boom")
 		})
 		assert.Equal(t, Rejected, p.state)
@@ -1206,9 +1204,9 @@ func TestPromise_ExecutorPanic(t *testing.T) {
 	})
 
 	t.Run("executor panic does not block Then chain", func(t *testing.T) {
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			panic("executor boom")
-		}).Catch(func(reason error) (interface{}, error) {
+		}).Catch(func(reason error) (any, error) {
 			return "recovered from: " + reason.Error(), nil
 		})
 		assert.Equal(t, Fulfilled, p.state)
@@ -1218,20 +1216,20 @@ func TestPromise_ExecutorPanic(t *testing.T) {
 
 func TestPromise_SubscriberPanicProtection(t *testing.T) {
 	t.Run("panicking subscriber does not block others", func(t *testing.T) {
-		var asyncResolve func(interface{}, error)
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		var asyncResolve func(any, error)
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			asyncResolve = resolve
 		})
 
 		// First subscriber will panic
-		result1 := p.Then(func(value interface{}) (interface{}, error) {
+		result1 := p.Then(func(value any) (any, error) {
 			panic("subscriber 1 panic")
 		}, nil)
 
 		// Second subscriber should still be called
 		done := make(chan struct{})
-		var result2Value interface{}
-		_ = p.Then(func(value interface{}) (interface{}, error) {
+		var result2Value any
+		_ = p.Then(func(value any) (any, error) {
 			result2Value = value
 			close(done)
 			return value, nil
@@ -1258,24 +1256,24 @@ func TestPromise_SubscriberPanicProtection(t *testing.T) {
 
 func TestPromise_SettlePanicProtection(t *testing.T) {
 	t.Run("multiple subscribers with mixed panic - first two panic, third succeeds (fulfilled)", func(t *testing.T) {
-		var asyncResolve func(interface{}, error)
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		var asyncResolve func(any, error)
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			asyncResolve = resolve
 		})
 
 		// First subscriber panics
-		result1 := p.Then(func(value interface{}) (interface{}, error) {
+		result1 := p.Then(func(value any) (any, error) {
 			panic("subscriber 1 boom")
 		}, nil)
 
 		// Second subscriber panics
-		result2 := p.Then(func(value interface{}) (interface{}, error) {
+		result2 := p.Then(func(value any) (any, error) {
 			panic("subscriber 2 boom")
 		}, nil)
 
 		// Third subscriber succeeds
 		done := make(chan struct{})
-		result3 := p.Then(func(value interface{}) (interface{}, error) {
+		result3 := p.Then(func(value any) (any, error) {
 			close(done)
 			return value, nil
 		}, nil)
@@ -1307,19 +1305,19 @@ func TestPromise_SettlePanicProtection(t *testing.T) {
 	})
 
 	t.Run("single panicking subscriber in rejected path does not block others", func(t *testing.T) {
-		var asyncReject func(interface{}, error)
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		var asyncReject func(any, error)
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			asyncReject = reject
 		})
 
 		// First subscriber panics
-		result1 := p.Then(nil, func(reason error) (interface{}, error) {
+		result1 := p.Then(nil, func(reason error) (any, error) {
 			panic("reject handler panic")
 		})
 
 		// Second subscriber handles rejection normally
 		done := make(chan struct{})
-		result2 := p.Then(nil, func(reason error) (interface{}, error) {
+		result2 := p.Then(nil, func(reason error) (any, error) {
 			close(done)
 			return nil, errors.New("handled: " + reason.Error())
 		})
@@ -1353,6 +1351,7 @@ func TestAggregateError_NilError(t *testing.T) {
 		assert.Equal(t, "All promises were rejected: err1, <nil>, err2", ae.Error())
 	})
 }
+
 // ---------- Round 3: 新增边界场景测试 ----------
 
 // TestPromise_MultiSubscriberPanicLifecycle
@@ -1364,8 +1363,8 @@ func TestAggregateError_NilError(t *testing.T) {
 func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 	t.Run("mixed panic and normal subscribers", func(t *testing.T) {
 		// Arrange: 创建 Pending 状态的 Promise，保留 resolve 引用用于手动触发
-		var asyncResolve func(interface{}, error)
-		source := NewPromise(func(resolve, reject func(interface{}, error)) {
+		var asyncResolve func(any, error)
+		source := NewPromise(func(resolve, reject func(any, error)) {
 			asyncResolve = resolve
 		})
 
@@ -1376,13 +1375,14 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 			called[i] = make(chan struct{})
 		}
 
-		// 5 个下游 Promise — 注意必须用局部变量捕获索引，避免闭包共享同一变量
+		// 5 个下游 Promise — idx 在各函数字面量内独立声明，闭包各自绑定独立索引；
+		// Go 1.22+ 循环变量已按迭代隔离，即使改写为循环也无需手动捕获
 		downstream := make([]*Promise, n)
 
 		// subscriber #1: panic
 		func() {
 			idx := 0
-			downstream[idx] = source.Then(func(value interface{}) (interface{}, error) {
+			downstream[idx] = source.Then(func(value any) (any, error) {
 				close(called[idx])
 				panic("boom from subscriber 1")
 			}, nil)
@@ -1391,7 +1391,7 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 		// subscriber #2: 正常
 		func() {
 			idx := 1
-			downstream[idx] = source.Then(func(value interface{}) (interface{}, error) {
+			downstream[idx] = source.Then(func(value any) (any, error) {
 				close(called[idx])
 				return fmt.Sprintf("sub2 got %v", value), nil
 			}, nil)
@@ -1400,7 +1400,7 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 		// subscriber #3: panic
 		func() {
 			idx := 2
-			downstream[idx] = source.Then(func(value interface{}) (interface{}, error) {
+			downstream[idx] = source.Then(func(value any) (any, error) {
 				close(called[idx])
 				panic("boom from subscriber 3")
 			}, nil)
@@ -1409,7 +1409,7 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 		// subscriber #4: 正常
 		func() {
 			idx := 3
-			downstream[idx] = source.Then(func(value interface{}) (interface{}, error) {
+			downstream[idx] = source.Then(func(value any) (any, error) {
 				close(called[idx])
 				return fmt.Sprintf("sub4 got %v", value), nil
 			}, nil)
@@ -1418,7 +1418,7 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 		// subscriber #5: panic
 		func() {
 			idx := 4
-			downstream[idx] = source.Then(func(value interface{}) (interface{}, error) {
+			downstream[idx] = source.Then(func(value any) (any, error) {
 				close(called[idx])
 				panic("boom from subscriber 5")
 			}, nil)
@@ -1473,7 +1473,7 @@ func TestPromise_MultiSubscriberPanicLifecycle(t *testing.T) {
 func TestPromise_DeepChainStackSafety(t *testing.T) {
 	t.Run("5000 layer synchronous Then chain", func(t *testing.T) {
 		// Arrange: 起始值 = 1
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve(1, nil)
 		})
 
@@ -1481,7 +1481,7 @@ func TestPromise_DeepChainStackSafety(t *testing.T) {
 		const layers = 5000
 		assert.NotPanics(t, func() {
 			for i := 0; i < layers; i++ {
-				p = p.Then(func(value interface{}) (interface{}, error) {
+				p = p.Then(func(value any) (any, error) {
 					return value.(int) + 1, nil
 				}, nil)
 			}
@@ -1498,7 +1498,7 @@ func TestPromise_DeepChainStackSafety(t *testing.T) {
 
 	t.Run("5000 layer synchronous Then chain with rejection propagation", func(t *testing.T) {
 		// 额外验证: 深层链中间某层 reject 后，后续层不再执行 onSuccess
-		p := NewPromise(func(resolve func(interface{}, error), reject func(interface{}, error)) {
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
 			resolve(1, nil)
 		})
 
@@ -1507,10 +1507,9 @@ func TestPromise_DeepChainStackSafety(t *testing.T) {
 
 		assert.NotPanics(t, func() {
 			for i := 0; i < 5000; i++ {
-				layer := i
-				p = p.Then(func(value interface{}) (interface{}, error) {
+				p = p.Then(func(value any) (any, error) {
 					successCallCount++
-					if layer == rejectAt {
+					if i == rejectAt {
 						return nil, errors.New("mid-chain rejection")
 					}
 					return value.(int) + 1, nil
@@ -1535,9 +1534,43 @@ func TestPromise_DeepChainStackSafety(t *testing.T) {
 	})
 }
 
+func TestPromise_DeepPendingChainSettle(t *testing.T) {
+	t.Run("10000 layer Then chain built on pending root", func(t *testing.T) {
+		var asyncResolve func(any, error)
+		p := NewPromise(func(resolve func(any, error), reject func(any, error)) {
+			asyncResolve = resolve
+		})
+
+		const layers = 10000
+		assert.NotPanics(t, func() {
+			for i := 0; i < layers; i++ {
+				p = p.Then(func(value any) (any, error) {
+					return value.(int) + 1, nil
+				}, nil)
+			}
+		}, "building 10000-layer Then chain on pending root should not panic")
+
+		assert.Equal(t, Pending, p.getState(),
+			"chain tail should still be Pending before root settles")
+
+		assert.NotPanics(t, func() {
+			asyncResolve(0, nil)
+		}, "settle cascade through 10000-layer pending chain should not panic")
+
+		assert.Equal(t, Fulfilled, p.getState(),
+			"final Promise should be Fulfilled after cascade settle")
+		assert.Equal(t, layers, p.GetValue(),
+			"final value should be 10000 (0 initial + 10000 increments)")
+		assert.Nil(t, p.GetReason(),
+			"final Promise should have no rejection reason")
+	})
+}
+
 // TestPromise_NilPromiseChainCalls
 // 场景: NewPromise(nil) 返回一个 Rejected Promise (Round 1 已修复)，
-//       验证其 Then/Catch/Finally 链式调用正常工作。
+//
+//	验证其 Then/Catch/Finally 链式调用正常工作。
+//
 // 验证:
 //   - NewPromise(nil).Then(...) 不 panic
 //   - NewPromise(nil).Catch(...) 可以捕获 "promise handler cannot be nil" 错误
@@ -1554,11 +1587,11 @@ func TestPromise_NilPromiseChainCalls(t *testing.T) {
 		// Then with explicit error handler: 捕获 error 并返回恢复值
 		assert.NotPanics(t, func() {
 			result := nilPromise.Then(
-				func(value interface{}) (interface{}, error) {
+				func(value any) (any, error) {
 					t.Fatal("success handler should not be called on Rejected Promise")
 					return nil, nil
 				},
-				func(reason error) (interface{}, error) {
+				func(reason error) (any, error) {
 					return "recovered via Then: " + reason.Error(), nil
 				},
 			)
@@ -1580,7 +1613,7 @@ func TestPromise_NilPromiseChainCalls(t *testing.T) {
 
 		// Catch 可以捕获 "promise handler cannot be nil"
 		assert.NotPanics(t, func() {
-			result := nilPromise.Catch(func(reason error) (interface{}, error) {
+			result := nilPromise.Catch(func(reason error) (any, error) {
 				return "caught: " + reason.Error(), nil
 			})
 			assert.Equal(t, Fulfilled, result.getState(),
@@ -1646,7 +1679,7 @@ func TestPromise_NilPromiseChainCalls(t *testing.T) {
 			finallyCalled := false
 
 			result := nilPromise.
-				Catch(func(reason error) (interface{}, error) {
+				Catch(func(reason error) (any, error) {
 					// 从 nil handler 错误中恢复
 					return "recovered from nil handler", nil
 				}).
@@ -1654,7 +1687,7 @@ func TestPromise_NilPromiseChainCalls(t *testing.T) {
 					finallyCalled = true
 					return nil
 				}).
-				Then(func(value interface{}) (interface{}, error) {
+				Then(func(value any) (any, error) {
 					return value.(string) + " and processed", nil
 				}, nil)
 
@@ -1668,16 +1701,16 @@ func TestPromise_NilPromiseChainCalls(t *testing.T) {
 		// 链式调用不恢复: Catch 再抛出 error
 		assert.NotPanics(t, func() {
 			result := nilPromise.
-				Catch(func(reason error) (interface{}, error) {
+				Catch(func(reason error) (any, error) {
 					return nil, errors.New("new error from Catch")
 				}).
 				Finally(func() error {
 					return nil
 				}).
-				Then(func(value interface{}) (interface{}, error) {
+				Then(func(value any) (any, error) {
 					t.Fatal("success handler should not be called on error propagation path")
 					return nil, nil
-				}, func(reason error) (interface{}, error) {
+				}, func(reason error) (any, error) {
 					return "handled: " + reason.Error(), nil
 				})
 
@@ -1694,14 +1727,14 @@ func TestPromise_ThenPendingToSettledRace(t *testing.T) {
 		// transitions from Pending to settled between snapshot() and Lock().
 		const iterations = 200
 		for i := 0; i < iterations; i++ {
-			var asyncResolve func(interface{}, error)
-			p := NewPromise(func(resolve, reject func(interface{}, error)) {
+			var asyncResolve func(any, error)
+			p := NewPromise(func(resolve, reject func(any, error)) {
 				asyncResolve = resolve
 			})
 
 			// Use channel to signal completion from Then callback
 			done := make(chan string, 1)
-			p.Then(func(v interface{}) (interface{}, error) {
+			p.Then(func(v any) (any, error) {
 				done <- v.(string) + "!"
 				return v, nil
 			}, nil)
@@ -1719,8 +1752,8 @@ func TestPromise_ThenPendingToSettledRace(t *testing.T) {
 	})
 
 	t.Run("multiple concurrent Then on settling promise", func(t *testing.T) {
-		var asyncResolve func(interface{}, error)
-		p := NewPromise(func(resolve, reject func(interface{}, error)) {
+		var asyncResolve func(any, error)
+		p := NewPromise(func(resolve, reject func(any, error)) {
 			asyncResolve = resolve
 		})
 
@@ -1728,7 +1761,7 @@ func TestPromise_ThenPendingToSettledRace(t *testing.T) {
 		done := make(chan string, n)
 
 		for i := 0; i < n; i++ {
-			p.Then(func(v interface{}) (interface{}, error) {
+			p.Then(func(v any) (any, error) {
 				done <- v.(string)
 				return v, nil
 			}, nil)
@@ -1745,6 +1778,306 @@ func TestPromise_ThenPendingToSettledRace(t *testing.T) {
 			case <-time.After(3 * time.Second):
 				t.Fatalf("timeout waiting for Then subscriber %d", i)
 			}
+		}
+	})
+}
+
+// TestPromise_RetainedResolveCannotAffectOtherPromises 回归测试（D1）：
+// handler 保留 resolve 引用并在 Promise 同步结算后再次调用属于合法用法，
+// 延迟调用必须是对原 Promise 的无操作（重复结算被忽略），
+// 绝不能决议任何其他 Promise。
+func TestPromise_RetainedResolveCannotAffectOtherPromises(t *testing.T) {
+	const rounds = 20
+	for round := 0; round < rounds; round++ {
+		var savedResolve func(any, error)
+		p1 := NewPromise(func(resolve, reject func(any, error)) {
+			savedResolve = resolve
+			resolve("p1-value", nil)
+		})
+		assert.Equal(t, Fulfilled, p1.getState(), "round %d: p1 should be Fulfilled", round)
+		assert.Equal(t, "p1-value", p1.GetValue(), "round %d: p1 initial value", round)
+
+		// 创建并同步结算一个无关 Promise，再创建一个保持 Pending 的无关 Promise
+		p2 := NewPromise(func(resolve, reject func(any, error)) {
+			resolve("p2-value", nil)
+		})
+		p3 := NewPromise(func(resolve, reject func(any, error)) {
+			// 刻意保持 Pending
+		})
+
+		// 延迟调用：按 JS Promise 语义必须是针对已结算 p1 的无操作
+		savedResolve("late-call", nil)
+
+		assert.Equal(t, "p1-value", p1.GetValue(), "round %d: p1 value must be unchanged by late resolve", round)
+		assert.Nil(t, p1.GetReason(), "round %d: p1 reason must remain nil", round)
+		assert.Equal(t, Fulfilled, p2.getState(), "round %d: settled p2 state must not change", round)
+		assert.Equal(t, "p2-value", p2.GetValue(), "round %d: settled p2 value must not change", round)
+		assert.Equal(t, Pending, p3.getState(), "round %d: pending p3 must not be settled by late resolve", round)
+		assert.Nil(t, p3.GetValue(), "round %d: pending p3 value must remain nil", round)
+		assert.Nil(t, p3.GetReason(), "round %d: pending p3 reason must remain nil", round)
+	}
+}
+
+// TestAggregateError_ConcurrentError 回归测试（D2）：
+// 对填充后的 *AggregateError 并发调用 Error() 与 InvalidateError()
+// 不得产生数据竞争（由 -race 验证），且 Error() 返回内容始终正确。
+func TestAggregateError_ConcurrentError(t *testing.T) {
+	ae := NewAggregateError(4)
+	for i := 0; i < 4; i++ {
+		ae.Errors = append(ae.Errors, fmt.Errorf("err-%d", i))
+	}
+	const expected = "All promises were rejected: err-0, err-1, err-2, err-3"
+
+	const goroutines = 8
+	const iterations = 2000
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if got := ae.Error(); got != expected {
+					t.Errorf("concurrent Error() returned %q, want %q", got, expected)
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				ae.InvalidateError()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, expected, ae.Error())
+}
+
+// TestPromise_AnyErrorsInInputOrder 回归测试（D6）：
+// 输入按 0,1,2,3,4 顺序，但以逆序/乱序错峰完成（完成顺序 1,3,4,2,0），
+// AggregateError.Errors 必须严格按输入顺序排列。
+func TestPromise_AnyErrorsInInputOrder(t *testing.T) {
+	delays := []time.Duration{100, 20, 80, 40, 60}
+	promises := make([]*Promise, len(delays))
+	for i := range delays {
+		promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+			go func() {
+				time.Sleep(delays[i])
+				reject(nil, fmt.Errorf("err-%d", i))
+			}()
+		})
+	}
+
+	done := make(chan struct{})
+	result := Any(promises...)
+	result.Then(nil, func(reason error) (any, error) {
+		close(done)
+		return nil, nil
+	})
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for Any all reject")
+	}
+
+	assert.Equal(t, Rejected, result.state)
+	aggErr, ok := result.reason.(*AggregateError)
+	assert.True(t, ok, "Expected reason to be an *AggregateError")
+	assert.Equal(t, len(delays), len(aggErr.Errors))
+	assert.Equal(t, "err-0", aggErr.Errors[0].Error())
+	assert.Equal(t, "err-1", aggErr.Errors[1].Error())
+	assert.Equal(t, "err-2", aggErr.Errors[2].Error())
+	assert.Equal(t, "err-3", aggErr.Errors[3].Error())
+	assert.Equal(t, "err-4", aggErr.Errors[4].Error())
+}
+
+// settleFanIn 让 workers 个 goroutine 在同一时刻开始结算 settlers 中的 Promise，
+// 模拟大规模并发扇入结算。
+func settleFanIn(settlers []func(), workers int) {
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			<-start
+			for j := base; j < len(settlers); j += workers {
+				settlers[j]()
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+}
+
+// TestPromise_RaceConcurrentFanIn 回归测试：
+// 16 个 goroutine 同时结算 128 个混合 fulfill/reject 的输入，
+// 重复 50 轮（配合 -race），Race 结果必须属于输入集合。
+func TestPromise_RaceConcurrentFanIn(t *testing.T) {
+	const (
+		n       = 128
+		workers = 16
+		rounds  = 50
+	)
+
+	allowedValues := make(map[int]struct{}, n)
+	allowedReasons := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		if i%3 == 0 {
+			allowedReasons[fmt.Sprintf("fanin err %d", i)] = struct{}{}
+		} else {
+			allowedValues[i] = struct{}{}
+		}
+	}
+
+	for round := 0; round < rounds; round++ {
+		promises := make([]*Promise, n)
+		settlers := make([]func(), n)
+		for i := 0; i < n; i++ {
+			if i%3 == 0 {
+				reason := fmt.Errorf("fanin err %d", i)
+				promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+					settlers[i] = func() { reject(nil, reason) }
+				})
+			} else {
+				promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+					settlers[i] = func() { resolve(i, nil) }
+				})
+			}
+		}
+
+		result := Race(promises...)
+		settled := make(chan struct{})
+		result.Then(func(value any) (any, error) {
+			close(settled)
+			return nil, nil
+		}, func(reason error) (any, error) {
+			close(settled)
+			return nil, nil
+		})
+
+		settleFanIn(settlers, workers)
+
+		select {
+		case <-settled:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("round %d: timeout waiting for Race fan-in settle", round)
+		}
+
+		switch result.getState() {
+		case Fulfilled:
+			v, ok := result.value.(int)
+			if !assert.True(t, ok, "round %d: Race value must be int", round) {
+				continue
+			}
+			_, allowed := allowedValues[v]
+			assert.True(t, allowed, "round %d: Race value %d not in input set", round, v)
+		case Rejected:
+			_, allowed := allowedReasons[result.reason.Error()]
+			assert.True(t, allowed, "round %d: Race reason %q not in input set", round, result.reason.Error())
+		default:
+			t.Fatalf("round %d: Race still pending after all inputs settled", round)
+		}
+	}
+}
+
+// TestPromise_AllConcurrentFanIn 回归测试：
+// 16 个 goroutine 同时结算 128 个输入，重复 50 轮（配合 -race）。
+// 全部 fulfill 时结果必须是完整有序值；混合 reject 时结果必须是首个拒绝错误之一。
+func TestPromise_AllConcurrentFanIn(t *testing.T) {
+	const (
+		n       = 128
+		workers = 16
+		rounds  = 50
+	)
+
+	t.Run("all fulfilled values in order", func(t *testing.T) {
+		for round := 0; round < rounds; round++ {
+			promises := make([]*Promise, n)
+			settlers := make([]func(), n)
+			for i := 0; i < n; i++ {
+				promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+					settlers[i] = func() { resolve(i, nil) }
+				})
+			}
+
+			result := All(promises...)
+			settled := make(chan struct{})
+			result.Then(func(value any) (any, error) {
+				close(settled)
+				return nil, nil
+			}, func(reason error) (any, error) {
+				close(settled)
+				return nil, nil
+			})
+
+			settleFanIn(settlers, workers)
+
+			select {
+			case <-settled:
+			case <-time.After(3 * time.Second):
+				t.Fatalf("round %d: timeout waiting for All fan-in settle", round)
+			}
+
+			assert.Equal(t, Fulfilled, result.getState(), "round %d", round)
+			values, ok := result.value.([]any)
+			if !assert.True(t, ok, "round %d: All value must be []any", round) {
+				continue
+			}
+			assert.Equal(t, n, len(values), "round %d", round)
+			for i := 0; i < n; i++ {
+				assert.Equal(t, i, values[i].(int), "round %d index %d", round, i)
+			}
+		}
+	})
+
+	t.Run("mixed rejects settled by first rejection", func(t *testing.T) {
+		allowedReasons := make(map[string]struct{})
+		for i := 0; i < n; i++ {
+			if i%5 == 0 {
+				allowedReasons[fmt.Sprintf("all err %d", i)] = struct{}{}
+			}
+		}
+
+		for round := 0; round < rounds; round++ {
+			promises := make([]*Promise, n)
+			settlers := make([]func(), n)
+			for i := 0; i < n; i++ {
+				if i%5 == 0 {
+					reason := fmt.Errorf("all err %d", i)
+					promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+						settlers[i] = func() { reject(nil, reason) }
+					})
+				} else {
+					promises[i] = NewPromise(func(resolve, reject func(any, error)) {
+						settlers[i] = func() { resolve(i, nil) }
+					})
+				}
+			}
+
+			result := All(promises...)
+			settled := make(chan struct{})
+			result.Then(func(value any) (any, error) {
+				close(settled)
+				return nil, nil
+			}, func(reason error) (any, error) {
+				close(settled)
+				return nil, nil
+			})
+
+			settleFanIn(settlers, workers)
+
+			select {
+			case <-settled:
+			case <-time.After(3 * time.Second):
+				t.Fatalf("round %d: timeout waiting for All fan-in settle", round)
+			}
+
+			assert.Equal(t, Rejected, result.getState(), "round %d", round)
+			_, allowed := allowedReasons[result.reason.Error()]
+			assert.True(t, allowed, "round %d: All reason %q must be one of the input rejections", round, result.reason.Error())
 		}
 	})
 }


### PR DESCRIPTION
All changes verified with go build, go vet, go test and go test -race.

Correctness fixes
- P0: retire closurePairPool. Retained resolve/reject closures reused after pooling could settle the wrong promise. NewPromise now creates inline closures (+2 allocs/op), an intended correctness-over-perf trade-off.
- P1: AggregateError cached string now uses atomic.Pointer[string], eliminating the data race on the cache path.

Performance
- All/AllSettled/Any/Race combinators: replace internal sync.Mutex with atomic.Int32/atomic.Bool CAS fan-in (lock-free). Same-session A/B: Race -12.5%, Any -17.5%, All -7.1%, AllSettled -6.9%; isolated combinator benchmarks improved by up to -32%.
- subscriber gains an index field and pointer passing, removing the per-subscriber wrapper closure on the pending path (AllPending: 778 -> 522 allocs/op, -17.5% ns/op).

Semantics
- Any: AggregateError.Errors is now ordered by input position, matching JavaScript Promise.any.

Modernization
- interface{} -> any across code, tests, benchmarks, examples and README; drop redundant loop-variable copies under Go 1.22+ scoping.

Tests
- Add 5 regression tests (D1/D2 pool reuse, Any input order, two concurrent fan-in cases, pending deep chain) and 2 pending-path benchmarks; split AggregateError benchmark into build/cached variants.

Documentation
- README documents Race([]) semantics, early-settlement retention, cascade stack depth and resolve(value, err) combinator routing; benchmark tables refreshed.

CI
- Enable go test -race in the pipeline.
- Expand os matrix to [ubuntu-latest, macos-15, windows-latest].

Chores
- Add .agent-work-b652f803 (agent work directory) to .gitignore.